### PR TITLE
Adds a ready endpoint for polling

### DIFF
--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -58,6 +58,10 @@ class SQLConfig(BaseModel):
 async def test(tasks: BackgroundTasks):
     return {"abc": 123, "tasks": tasks.tasks}
 
+@app.get("/ready")
+async def ready():
+    return {"ok": True}
+
 @app.post("/push")
 async def push_unparsed_manifest(manifest: UnparsedManifestBlob):
     # Parse / validate it


### PR DESCRIPTION
Adds a new `/ready` endpoint that only returns an `ok` status-- for use in polling for readiness to except requests