### PR TITLE
build container for postgres, bigquery, and redshift as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         dbt-core-version: [0.21.0]
-        dbt-database-adapter: [snowflake]
+        dbt-database-adapter: [snowflake, postgres, bigquery, redshift]
     steps:
       - name: checkout code
         uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         dbt-core-version: [0.21.0]
-        dbt-database-adapter: [snowflake]
+        dbt-database-adapter: [snowflake, postgres, bigquery, redshift]
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds other database adapters to the build matrix.

This is blocked by adding repos to ECR for this containers (https://github.com/dbt-labs/dbt-cloud-infra-terraform/pull/353)