### PR TITLE
Adds endpoint for deleting server deployment

### DIFF
--- a/dbt_server/services/kubernetes_service.py
+++ b/dbt_server/services/kubernetes_service.py
@@ -1,0 +1,29 @@
+from kubernetes import client, config
+from dbt.logger import log_manager, GLOBAL_LOGGER as logger
+import os
+
+
+def delete_server_deployment(deployment_name):
+    apps_v1_api = None
+
+    try:
+        config.load_incluster_config()
+        apps_v1_api = client.AppsV1Api()
+
+    except Exception as e:
+        logger.warning(f"Failed to initialize kubernetes client. Error {e}")
+
+    pod_namespace = os.getenv("POD_NAMESPACE")
+    result = None
+    try:
+        result = apps_v1_api.delete_namespaced_deployment(
+            name=deployment_name,
+            namespace=pod_namespace,
+            body=client.V1DeleteOptions(
+                propagation_policy="Foreground"
+            ),
+            _request_timeout=300,
+        )
+    except client.rest.ApiException:
+        pass
+    return result

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -12,6 +12,8 @@ from typing import List, Optional
 from .services import filesystem_service
 from .services import dbt_service
 from .services import task_service
+from .services import kubernetes_service
+
 from .logging import GLOBAL_LOGGER as logger
 
 # ORM stuff
@@ -55,6 +57,8 @@ class ListArgs(BaseModel):
     output_keys: Optional[List[str]] = None
     threads: int = 4
 
+class DeleteArgs(BaseModel):
+    deployment_name: str
 
 class SQLConfig(BaseModel):
     state_id: Optional[str] = None
@@ -152,6 +156,21 @@ async def list_resources(args: ListArgs):
         "ok": True,
     }
 
+
+@app.post("/delete")
+def delete_deployment(args: DeleteArgs):
+    deleted_deployment = kubernetes_service.delete_server_deployment(args.deployment_name)
+    if deleted_deployment is None:
+        return {
+            "res": None,
+            "ok": False,
+        }
+    encoded_deployment = jsonable_encoder(deleted_deployment)
+
+    return {
+        "res": encoded_deployment,
+        "ok": True,
+    }
 
 @app.post("/run-async")
 async def run_models_async(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ websockets==9.1
 SQLAlchemy==1.4.23
 diff-match-patch==20200713
 sse-starlette==0.9.0
+kubernetes==10.0.0


### PR DESCRIPTION
Adds a `/delete` endpoint that deletes a dbt-server deployment by name.

This has been tested locally-- I'm not 100% sure we'll have the permissions necessary to do this to a different user's pod in prod (or if we want to expose this ability to users if permissions do extend across all pods). 

See client pr: https://github.com/dbt-labs/dbt-client/pull/7