### PR TITLE
Adds support for dbt Deps

### DIFF
--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -57,28 +57,30 @@ def compile_sql(manifest, project_path, sql):
 def render_package_data(packages):
     return json.loads(packages)
 
-def get_tarballs(package_data):
-    tarballs = []
+def get_package_details(package_data):
+    packages = []
     for package in package_data.get('packages', {}):
-        name = package.get('package')
+        full_name = package.get('package')
         version = package.get('version')
-        if not name or not version:
-            # TODO: Something better than this
+        if not full_name or not version:
+            # TODO: Something better than this for detecting Hub packages?
             logger.debug(
                 f'Skipping package: {package}. '
                 'Either non-hub package or missing package version.'
             )
             continue
-        tar_name = '{}.{}.tar.gz'.format(name, version)
-        # TODO: Handle 404s for invalid packages
-        package_details = package_version(name, version)
+        tar_name = '{}.{}.tar.gz'.format(full_name, version)
+        package_details = package_version(full_name, version)
         tarball = package_details.get('downloads', {}).get('tarball')
+        name = package_details.get('name')
         
-        tarballs.append({
+        packages.append({
+            # Hack to imitate core package name
+            "package": f'{full_name}@{version}',
             "name": name,
             "version": version,
             "tar_name": tar_name,
             "tarball": tarball
         })         
     
-    return tarballs
+    return packages

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -1,5 +1,6 @@
 import os
 import json
+from requests.exceptions import HTTPError
 
 from sse_starlette.sse import EventSourceResponse
 from fastapi import FastAPI, BackgroundTasks, Depends
@@ -203,11 +204,19 @@ async def compile_sql(sql: SQLConfig):
 @app.post("/deps")
 async def tar_deps(args: DepsArgs):
     package_data = dbt_service.render_package_data(args.packages)
-    tarballs = dbt_service.get_tarballs(package_data)
-    return {
-        "ok": True,
-        "res": jsonable_encoder(tarballs),
-    }
+    try:
+        packages = dbt_service.get_package_details(package_data)
+        return {
+            "ok": True,
+            "res": jsonable_encoder(packages)
+        }
+    # Temporary solution for bubbling up client errors until we
+    # have more sophisticated response objects.
+    except HTTPError as e:
+        return {
+            "ok": False,
+            "error": str(e)
+        }
 
 class Task(BaseModel):
     task_id: str


### PR DESCRIPTION
Adds a `/deps` endpoint that expects a dict of packages with package (name) and version keys, uses the core function `package_version` to make a call to the hub API for package details, and returns all necessary details for package installation to the client.

Right now I'm differentiating hub packages by expecting the `package` and `version` keys (as other package types use different keys). I have no idea whether or not this is sound. As it stands, if the package requested is not available on the hub site, the server will return the error to the client (status will be 200, but `ok` will be `False` and the data will contain the error). If [this dbt-server PR](https://github.com/dbt-labs/dbt-server/pull/32) is approved, I'll update this handling to match RuntimeException handling (though perhaps not with a blanket catch) and will update handling client-side accordingly. 

Corresponding PR in dbt-client: https://github.com/dbt-labs/dbt-client/pull/10
Small change made to dbt-core: https://github.com/dbt-labs/dbt-core/pull/4218