### PR TITLE
Update new command endpoints

### DIFF
--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from dbt_server.logging import GLOBAL_LOGGER as logger
 
 ROOT_PATH = "./working-dir"
 
@@ -49,6 +50,9 @@ def write_unparsed_manifest_to_disk(state_id, filedict):
 def get_latest_state_id(state_id):
     if not state_id:
         path = os.path.abspath(get_latest_state_file_path())
+        if not os.path.exists(path):
+            logger.error("No state id included in request, no previous state id found.")
+            return None
         with open(path, 'r') as latest_path_file:
             state_id = latest_path_file.read()
     return state_id

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -309,6 +309,13 @@ async def run_operation_async(
 @app.post("/preview")
 async def preview_sql(sql: SQLConfig):
     state_id = filesystem_service.get_latest_state_id(sql.state_id)
+    if state_id is None:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "message": "No historical record of a successfully parsed project for this user environment."
+            },
+    )
     path = filesystem_service.get_root_path(state_id)
     serialize_path = filesystem_service.get_path(state_id, 'manifest.msgpack')
 
@@ -336,6 +343,13 @@ async def preview_sql(sql: SQLConfig):
 @app.post("/compile")
 async def compile_sql(sql: SQLConfig):
     state_id = filesystem_service.get_latest_state_id(sql.state_id)
+    if state_id is None:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "message": "No historical record of a successfully parsed project for this user environment."
+            },
+    )
     path = filesystem_service.get_root_path(state_id)
     serialize_path = filesystem_service.get_path(state_id, 'manifest.msgpack')
 


### PR DESCRIPTION
* Adds needed args to snapshot and run-operation
* Adds handling in case metrics layer runs a query with no state history (we expect failure in these cases, but would like to return a 400 error instead of hitting a FileNotFoundError.