### PR TITLE
Updates run operation arg 'args' to a string

### DIFF
--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -114,7 +114,7 @@ class RunOperationArgs(BaseModel):
     state_id: str
     macro: str
     single_threaded: bool = False
-    args: str = '{}'
+    args: str = Field(default_factory='{}')
 
 
 class SQLConfig(BaseModel):


### PR DESCRIPTION
The 'args' option in run-operation is actually expected to be a yaml string per [dbt docs](https://docs.getdbt.com/reference/commands/run-operation#usage). I confirmed that core also defaults this value to '{}'.