### PR TITLE
Update ci/cd to build images for dbt-core 1.0.0 and 1.0.1

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -26,6 +26,10 @@ inputs:
   registry-password:
     description: "The password to use when authenticating to the registry"
     required: true
+  push:
+    description: "Determines if image should be pushed to registry, `true` be default"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -52,4 +56,4 @@ runs:
         target: ${{ inputs.docker-file-target }}
         ssh: ${{ inputs.docker-ssh-agents }}
         tags: ${{ github.event_name == 'push' && format('{0}, {1}', env.VERSION_TAG, env.LATEST_TAG) || env.VERSION_TAG }}
-        push: true
+        push: ${{ inputs.push }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
 
   build-staging-image:
     name: build and publish staging image
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,6 +61,7 @@ jobs:
           registry-endpoint: ${{ secrets.STAGING_FROM_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com
           registry-username: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           registry-password: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          push: ${{ github.event_name == 'push' }}
 
   build-production-image:
     name: build and publish production image
@@ -69,34 +69,57 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        dbt-core:
+          - version: "1.0.0"
+            package: "dbt-core==1.0.0"
+          - version: "1.0.1"
+            package: "dbt-core==1.0.1"
+        dbt-database-adapter:
+          - name: snowflake
+            package: dbt-snowflake
+          - name: bigquery
+            package: dbt-bigquery
+          - name: postgres
+            package: dbt-postgres
+          - name: redshift
+            package: dbt-redshift
         include:
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: snowflake
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: postgres
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: redshift
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-redshift/archive/HEAD.tar.gz#egg=dbt-redshift
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: bigquery
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-bigquery/archive/HEAD.tar.gz#egg=dbt-bigquery
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: snowflake
+              package: https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: postgres
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: redshift
+              package: https://github.com/dbt-labs/dbt-redshift/archive/HEAD.tar.gz#egg=dbt-redshift
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: bigquery
+              package: https://github.com/dbt-labs/dbt-bigquery/archive/HEAD.tar.gz#egg=dbt-bigquery
     steps:
       - name: checkout code
         uses: actions/checkout@v2
 
       - uses: ./.github/actions/docker-build-and-push
         with:
-          image-name: dbt-server-${{ matrix.dbt-database-adapter }}-${{ matrix.dbt-core-version }}
+          image-name: dbt-server-${{ matrix.dbt-database-adapter.name }}-${{ matrix.dbt-core.version }}
           docker-file-path: Dockerfile
           docker-build-args: |
-            DBT_CORE_PACKAGE=${{ matrix.dbt-core-package }}
-            DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter-package }}
+            DBT_CORE_PACKAGE=${{ matrix.dbt-core.package }}
+            DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter.package }}
           registry-endpoint: ${{ secrets.INFRA_ROOT_FROM_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com
           registry-username: ${{ secrets.INFRA_ROOT_AWS_ACCESS_KEY_ID }}
           registry-password: ${{ secrets.INFRA_ROOT_AWS_SECRET_ACCESS_KEY }}
+          push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
- update GHA to build 1.0.0 and 1.0.1 image
- build images on every ci trigger, only push images on push to main. this might get noisy, so I'm good to revert this at some point. this will also crop up any build and dbt-core/dbt-adapter compatibility issues before merging PRs