### PR TITLE
Build same images for prod and staging accounts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,34 +30,56 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        dbt-core:
+          - version: "1.0.0"
+            package: "dbt-core==1.0.0"
+          - version: "1.0.1"
+            package: "dbt-core==1.0.1"
+        dbt-database-adapter:
+          - name: snowflake
+            package: dbt-snowflake
+          - name: bigquery
+            package: dbt-bigquery
+          - name: postgres
+            package: dbt-postgres
+          - name: redshift
+            package: dbt-redshift
         include:
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: snowflake
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: postgres
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: redshift
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-redshift/archive/HEAD.tar.gz#egg=dbt-redshift
-          - dbt-core-version: head
-            dbt-core-package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            dbt-database-adapter: bigquery
-            dbt-database-adapter-package: https://github.com/dbt-labs/dbt-bigquery/archive/HEAD.tar.gz#egg=dbt-bigquery
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: snowflake
+              package: https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: postgres
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: redshift
+              package: https://github.com/dbt-labs/dbt-redshift/archive/HEAD.tar.gz#egg=dbt-redshift
+          - dbt-core:
+              version: head
+              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+            dbt-database-adapter:
+              name: bigquery
+              package: https://github.com/dbt-labs/dbt-bigquery/archive/HEAD.tar.gz#egg=dbt-bigquery
     steps:
       - name: checkout code
         uses: actions/checkout@v2
 
       - uses: ./.github/actions/docker-build-and-push
         with:
-          image-name: dbt-server-${{ matrix.dbt-database-adapter }}-${{ matrix.dbt-core-version }}
+          image-name: dbt-server-${{ matrix.dbt-database-adapter.name }}-${{ matrix.dbt-core.version }}
           docker-file-path: Dockerfile
           docker-build-args: |
-            DBT_CORE_PACKAGE=${{ matrix.dbt-core-package }}
-            DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter-package }}
+            DBT_CORE_PACKAGE=${{ matrix.dbt-core.package }}
+            DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter.package }}
           registry-endpoint: ${{ secrets.STAGING_FROM_ACCOUNT }}.dkr.ecr.us-east-1.amazonaws.com
           registry-username: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
           registry-password: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Currently block from running this in a staging environment end-to-end because of missing docker images. This will build the same images that are available in production, but for our staging env. 