### PR TITLE
Pin MarkupSafe version to 2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt $DBT_CORE_PACKAGE $DBT_DATABASE_ADAPTER_PACKAGE
+RUN pip install --force-reinstall MarkupSafe==2.0.1 # TODO: find better fix for this
 
 COPY ./dbt_server /usr/src/app/dbt_server


### PR DESCRIPTION
Back in February MarkupSafe released a new version of the package that does not include `soft_unicode`. Turns out Jinja has a dependency on MarkupSafe which is not pinned, so when MarkupSafe was updated it ended up breaking Jinja and subsequently [dbt deps as shown by this community member](https://github.com/dbt-labs/dbt-core/issues/4745).

This PR adds the hot-fix suggested in the thread, we should discuss with core what the long-term solution for this is.