### PR TITLE
Improve shutdown endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,15 @@ From the root of the repo, with the virtualenv sourced:
 uvicorn dbt_server.server:app --reload --host=127.0.0.1 --port 8580
 ```
 
-### Workspace Mode
-`WORKSPACE_MODE` overrides the signal handling for `SIGINT` and `SIGTERM` to allow the server to continue accepting requests after receiving either signal. A second signal will terminate the server normally.
-`WORKSPACE_MODE` also enables the `POST /workspace-shutdown` endpoint, which is intended to be called by the Workspace Controller in a Workspace pod to forcefully shutdown the server, when there is no more work to process.
-
-**NOTE: `WORKSPACE_MODE` is the default mode that dbt-server will run in, since it is how it should run in deployed environments.**
+### ALLOW_ORCHESTRATED_SHUTDOWN
+`ALLOW_ORCHESTRATED_SHUTDOWN` overrides the signal handling for `SIGINT` and `SIGTERM` to allow the server to continue accepting requests after receiving either signal. A second signal will terminate the server normally.
+`ALLOW_ORCHESTRATED_SHUTDOWN` also enables the `POST /shutdown` endpoint, which can be called by another application that controls the lifetime of dbt server.
 
 **NOTE: The signal handling overrides do not work properly with the `--reload` flag, so be sure to remove it to test or iterate on this functionality (everything else works fine and the server will restart as expected).**
 
-To run without `WORKSPACE_MODE`, set the env var `WORKSPACE_MODE=off`:
+To run with `ALLOW_ORCHESTRATED_SHUTDOWN`, set the env var `ALLOW_ORCHESTRATED_SHUTDOWN=on`:
 ```console
-WORKSPACE_MODE=off uvicorn dbt_server.server:app --reload --host=127.0.0.1 --port 8580
+ALLOW_ORCHESTRATED_SHUTDOWN=on uvicorn dbt_server.server:app --reload --host=127.0.0.1 --port 8580
 ```
 
 ### Building docker container locally

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -1,10 +1,11 @@
 import asyncio
 import os
 import signal
+from tkinter import ALL
 
 from . import models
 from .database import engine
-from .views import WORKSPACE_MODE, app
+from .views import ALLOW_ORCHESTRATED_SHUTDOWN, app
 from .services import dbt_service
 
 # Where... does this actually go?
@@ -17,7 +18,7 @@ dbt_service.disable_tracking()
 
 @app.on_event("startup")
 async def startup_event():
-    if WORKSPACE_MODE:
+    if ALLOW_ORCHESTRATED_SHUTDOWN:
         override_signal_handlers()
 
 

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -23,10 +23,9 @@ from sqlalchemy.orm import Session
 from . import crud
 from . import schemas
 
-# Enable WORKSPACE_MODE to run dbt server in a runtime workspace pod,
-# which overrides os signal handling to allow the workspace controller
-# to send remaining tasks on shutdown
-WORKSPACE_MODE = os.environ.get('WORKSPACE_MODE', '1').lower() in ('true', '1', 'on')
+# Enable `ALLOW_ORCHESTRATED_SHUTDOWN` to instruct dbt server to
+# ignore a first SIGINT or SIGTERM and enable a `/shutdown` endpoint
+ALLOW_ORCHESTRATED_SHUTDOWN = os.environ.get('ALLOW_ORCHESTRATED_SHUTDOWN', '0').lower() in ('true', '1', 'on')
 
 app = FastAPI()
 
@@ -200,9 +199,9 @@ async def test(tasks: BackgroundTasks):
     return {"abc": 123, "tasks": tasks.tasks}
 
 
-if WORKSPACE_MODE:
-    @app.post("/workspace-shutdown")
-    async def workspace_shutdown():
+if ALLOW_ORCHESTRATED_SHUTDOWN:
+    @app.post("/shutdown")
+    async def shutdown():
         # raise 2 SIGTERM signals, just to
         # make sure this really shuts down.
         # raising a SIGKILL logs some


### PR DESCRIPTION
use 2 sigterm signals to shutdown the server in the workspace-shutdown endpoint. using a sigkill logs warnings about leaked semaphores. this is way cleaner, anyway.

Per convo with Drew, I've renamed `WORKSPACE_MODE` to `ALLOW_ORCHESTRATED_SHUTDOWN` and defaulted it to off/false. README has been updated accordingly and removed references to anything runtime specific.