### PR TITLE
clean up error logging; catch profile config exceptions

### DIFF
--- a/dbt_server/exceptions.py
+++ b/dbt_server/exceptions.py
@@ -1,4 +1,2 @@
-
-
 class InvalidConfigurationException(Exception):
     pass

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -6,9 +6,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from dbt_server.services import filesystem_service
-from dbt_server.exceptions import (
-    InvalidConfigurationException
-)
+from dbt_server.exceptions import InvalidConfigurationException
 
 from dbt.clients.registry import package_version, get_available_versions
 from dbt import semver

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -16,9 +16,7 @@ from .services import dbt_service
 from .services import task_service
 from .logging import GLOBAL_LOGGER as logger
 
-from dbt_server.exceptions import (
-    InvalidConfigurationException
-)
+from dbt_server.exceptions import InvalidConfigurationException
 
 # ORM stuff
 from sqlalchemy.orm import Session
@@ -186,7 +184,9 @@ class SQLConfig(BaseModel):
 
 
 @app.exception_handler(InvalidConfigurationException)
-async def configuration_exception_handler(request: Request, exc: InvalidConfigurationException):
+async def configuration_exception_handler(
+    request: Request, exc: InvalidConfigurationException
+):
     exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
     logger.error(f"Request to {request.url} failed validation: {exc_str}")
     content = {"status_code": 422, "message": exc_str, "data": None}


### PR DESCRIPTION
This PR cleans up some extra-verbose logging that was temporarily added to the `/parse` endpoint. We can circle back in the future to do this in more appropriate ways & across all endpoints. For now though, the log output of the dbt-server will be significantly less chatty.

This PR also re-raises validation errors from dbt Core as InvalidConfigurationExceptions. This is an important change because some types of dbt Core exceptions may contain sensitive information. Here's an example that's easy to reproduce:

1. Create a `profiles.yml` file with invalid quoting

```yml
user:
  target: dev
  outputs:
    dev:
      type: snowflake
      account: accountname
      database: dbname
      password: {abc123   # This needs to be quoted! it is not valid!
      role: rolename
      schema: dbt_dbanin
      threads: 8
      user: drew
      warehouse: warehousename
```

This is _not_ a valid yaml specification, but an upstream tool could errantly omit quotes around the password string. This would cause dbt Core to raise an exception containing a message that says:

```
  dbt encountered an error while trying to read your profiles.yml file.

  Runtime Error
    Syntax error near line 9
    ------------------------------
    6  |       account: accountname
    7  |       database: dbname
    8  |       password: {abc123
    9  |       role: rolename
    10 |       schema: dbt_dbanin
    11 |       threads: 8
    12 |       user: drew

    Raw Error:
    ------------------------------
    while parsing a flow mapping
      in "<unicode string>", line 8, column 17:
              password: {abc123
                        ^
    expected ',' or '}', but got ':'
      in "<unicode string>", line 9, column 11:
              role: drew
```

don't get me wrong - this is a beautiful error message - but we don't want it in the stdout for dbt servers :)