### PR TITLE
Catches compilation errors

### DIFF
--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -445,7 +445,7 @@ def compile_sql(sql: SQLConfig):
     except CompilationException as e:
         return JSONResponse(
             status_code=400,
-            content={"message": str(e)},
+            content={"message": repr(e)},
         )
 
     if type(result) != RemoteCompileResult:


### PR DESCRIPTION
Result of running:
```
curl localhost:8580/compile -H 'Content-Type: application/json' -d '{"state_id":"c88a8c249f7675b008a24ad18b4c33ec", "sql":"select * from {{ metrics.calculate(metric('sales_volume_by_product_type'), grain='month', dimensions=['PRODUCTTYPE'], secondary_calculations=[metrics.period_over_period(comparison_strategy=\"ratio\", interval=1, alias=\"\")]) }}"}'
```
Before:
```Internal Server Error```

After:
```{"message":"Compilation Error in sql name (from remote system)\n  'metrics' is undefined. This can happen when calling a macro that does not exist. Check for typos and/or install package dependencies with \"dbt deps\"."}```