### PR TITLE
add datadog tracing

### DIFF
--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -1,3 +1,6 @@
+# Need to run this as early in the server's startup as possible
+from . import tracer  # noqa
+
 import asyncio
 import signal
 

--- a/dbt_server/tracer.py
+++ b/dbt_server/tracer.py
@@ -1,0 +1,24 @@
+import os
+
+APM_ENABLED = os.getenv("APPLICATION_TRACING_ENABLED", "")
+
+ENV_HAS_DDTRACE = False
+TRACING_ENABLED = False
+
+try:
+    import ddtrace
+
+    ENV_HAS_DDTRACE = True
+except (ModuleNotFoundError, ImportError):
+    pass
+
+
+def setup_tracing():
+    global TRACING_ENABLED
+
+    if ENV_HAS_DDTRACE and APM_ENABLED:
+        TRACING_ENABLED = True
+        ddtrace.patch_all()
+
+
+setup_tracing()


### PR DESCRIPTION
Adds datadog tracing via `patch_all` if:
 - `ddtrace` is installed in the python env AND
 - `APPLICATION_TRACING_ENABLED` env var is set to a truthy value

I'd ideally also be able to log out info about patching, but we need to call `patch_all` before the logger is initialized