### PR TITLE
enable perf monitoring, add traces

### DIFF
--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from dbt_server.logging import GLOBAL_LOGGER as logger
+from dbt_server import tracer
 
 ROOT_PATH = "./working-dir"
 
@@ -17,12 +18,14 @@ def get_path(state_id, *path_parts):
     return os.path.join(get_root_path(state_id), *path_parts)
 
 
+@tracer.wrap
 def ensure_dir_exists(path):
     dirname = os.path.dirname(path)
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
 
+@tracer.wrap
 def write_file(path, contents):
     ensure_dir_exists(path)
 
@@ -32,11 +35,13 @@ def write_file(path, contents):
         fh.write(contents)
 
 
+@tracer.wrap
 def read_file(path):
     with open(path, "rb") as fh:
         return fh.read()
 
 
+@tracer.wrap
 def write_unparsed_manifest_to_disk(state_id, filedict):
     root_path = get_root_path(state_id)
     if os.path.exists(root_path):
@@ -47,6 +52,7 @@ def write_unparsed_manifest_to_disk(state_id, filedict):
         write_file(path, file_info.contents)
 
 
+@tracer.wrap
 def get_latest_state_id(state_id):
     if not state_id:
         path = os.path.abspath(get_latest_state_file_path())
@@ -58,6 +64,7 @@ def get_latest_state_id(state_id):
     return state_id
 
 
+@tracer.wrap
 def update_state_id(state_id):
     path = os.path.abspath(get_latest_state_file_path())
     with open(path, "w+") as latest_path_file:

--- a/dbt_server/tracer.py
+++ b/dbt_server/tracer.py
@@ -1,12 +1,18 @@
 import os
 
-APM_ENABLED = os.getenv("APPLICATION_TRACING_ENABLED", "")
+APM_ENABLED = os.getenv("APPLICATION_TRACING_ENABLED", "") not in (
+    "",
+    "0",
+    "f",
+    "false",
+)
 
 ENV_HAS_DDTRACE = False
 TRACING_ENABLED = False
 
 try:
     import ddtrace
+    import ddtrace.profiling.auto
 
     ENV_HAS_DDTRACE = True
 except (ModuleNotFoundError, ImportError):
@@ -19,6 +25,26 @@ def setup_tracing():
     if ENV_HAS_DDTRACE and APM_ENABLED:
         TRACING_ENABLED = True
         ddtrace.patch_all()
+
+
+def wrap(func):
+    """
+    Decorator that adds datadog tracing if ddtrace
+    is installed and enabled, otherwise it's a no-op
+    """
+
+    def no_op(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    def dd_trace(*args, **kwargs):
+        name = f"{func.__module__}.{func.__name__}"
+        with ddtrace.tracer.trace(name):
+            return func(*args, **kwargs)
+
+    if ENV_HAS_DDTRACE and APM_ENABLED:
+        return dd_trace
+    else:
+        return no_op
 
 
 setup_tracing()


### PR DESCRIPTION
This PR:
 - turns performance monitoring / profiling on
 - adds specific traces within the dbt-server function calls (though we can't reach into dbt Core, which is a shame!)