### PR TITLE
Fix logger timestamp

### DIFF
--- a/dbt_server/logging.py
+++ b/dbt_server/logging.py
@@ -21,12 +21,12 @@ from .models import TaskState
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
-        if not log_record.get('timestamp'):
+        if not log_record.get("timestamp"):
             created = datetime.utcnow()
             if record.created:
                 created = datetime.utcfromtimestamp(record.created)
-            now = created.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-            log_record['timestamp'] = now
+            now = created.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            log_record["timestamp"] = now
 
 
 # setup json logging


### PR DESCRIPTION
update logger to set the log's timestamp to a variable name `timestamp` known to datadog and in a format known to datadog
![Screen Shot 2022-08-26 at 12 36 06 PM](https://user-images.githubusercontent.com/5214436/186978887-8d3c7423-eeaf-4bb8-91d7-f49b84cb69e1.png)
