### PR TITLE
(RUNTIME-430) build 1.2 prerelease images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,9 @@ jobs:
             package: "dbt-core==1.1.1"
           - version: "1.2.0"
             package: "dbt-core==1.2.0"
+          - version: "1.2.0-pre"
+            package: "dbt-core==1.2.0b1"
+            prerelease: true
           - version: "1.2.0-latest"
             package: "dbt-core==1.2.0"
         dbt-database-adapter:
@@ -133,6 +136,8 @@ jobs:
           image-name: dbt-server-${{ matrix.dbt-database-adapter.name }}-${{ matrix.dbt-core.version }}
           docker-file-path: Dockerfile
           docker-build-args: |
+            # Use --pre flag when installing this version if it's a prerelease
+            DBT_PIP_FLAGS=${{ (matrix.dbt-core.prerelease && '--pre') || '' }}
             DBT_CORE_PACKAGE=${{ matrix.dbt-core.package }}
             DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter.package }}
             DATADOG_PACKAGE=ddtrace==1.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 ARG BASE_IMAGE=python@sha256:bb908c726535fc6787a69d4ef3cdb5ee90dc5edeae56da3181b2108539a5eb64
 FROM $BASE_IMAGE
 
+ARG DBT_PIP_FLAGS
 ARG DBT_CORE_PACKAGE
 ARG DBT_DATABASE_ADAPTER_PACKAGE
 ARG DATADOG_PACKAGE
@@ -18,7 +19,15 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app
 
-RUN pip install --no-cache-dir --upgrade -r requirements.txt $DBT_CORE_PACKAGE $DBT_DATABASE_ADAPTER_PACKAGE ${DATADOG_PACKAGE}
+RUN pip install                     \
+    --no-cache-dir                  \
+    --upgrade                       \
+    -r requirements.txt             \
+    ${DBT_PIP_FLAGS}                \
+    ${DBT_CORE_PACKAGE}             \
+    ${DBT_DATABASE_ADAPTER_PACKAGE} \
+    ${DATADOG_PACKAGE}
+
 RUN pip install --force-reinstall MarkupSafe==2.0.1 # TODO: find better fix for this
 
 COPY ./dbt_server /usr/src/app/dbt_server


### PR DESCRIPTION
This PR builds the 1.2b1 pre-release image for the dbt-server. Note that right now, prereleases will need to be maintained manually, which... isn't great! Let's treat this as a stop-gap and circle back to a more mature approach in the future