### PR TITLE
Support latest patch for latest and pre versions of core.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,20 +68,21 @@ jobs:
       matrix:
         dbt-core:
           - version: "1.0.0"
-            package: "dbt-core==1.0.0"
+            package: "dbt-core~=1.0.0"
           - version: "1.0.1"
-            package: "dbt-core==1.0.1"
-          - version: "1.1.0"
-            package: "dbt-core==1.1.0"
+            package: "dbt-core~=1.0.1"
+          - version: "1.1.0-pre"
+            package: "dbt-core~=1.1.0b1"
           - version: "1.1.0-latest"
-            package: "dbt-core==1.1.1"
-          - version: "1.2.0"
-            package: "dbt-core==1.2.0"
+            package: "dbt-core~=1.1.1"
           - version: "1.2.0-pre"
-            package: "dbt-core==1.2.0b1"
+            package: "dbt-core~=1.2.0b1"
             prerelease: true
           - version: "1.2.0-latest"
-            package: "dbt-core==1.2.0"
+            package: "dbt-core~=1.2.0"
+          - version: "1.3.0-pre"
+            package: "dbt-core~=1.3.0b1"
+            prerelease: true
         dbt-database-adapter:
           - name: snowflake
             package: dbt-snowflake
@@ -140,7 +141,7 @@ jobs:
             DBT_PIP_FLAGS=${{ (matrix.dbt-core.prerelease && '--pre') || '' }}
             DBT_CORE_PACKAGE=${{ matrix.dbt-core.package }}
             DBT_DATABASE_ADAPTER_PACKAGE=${{ matrix.dbt-database-adapter.package }}
-            DATADOG_PACKAGE=ddtrace==1.3.2
+            DATADOG_PACKAGE=ddtrace==1.4.4
           staging-registry-endpoint: ${{ secrets.STAGING_REGISTRY_ENDPOINT }}
           production-registry-endpoint: ${{ secrets.INFRA_ROOT_REGISTRY_ENDPOINT }}
           push: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
This PR conforms the `dbt-core` versions being built into `dbt-server` with those being used by cloud.

The supported versions of `dbt-core` can be found in [dbt_versions.py](https://github.com/dbt-labs/dbt-cloud/blob/2ce3d86093c685440833d028671deeb66fc02c3b/sinter/models/constants/dbt_versions.py#L246) in cloud and the corresponding
[Dockerfiles](https://github.com/dbt-labs/dbt-cloud/tree/2ce3d86093c685440833d028671deeb66fc02c3b/docker) show how the versions are defined for pip, using `~=`, rather than `==`. This will always use the latest patch version.

The updates in this PR to the GH Actions workflow update the way we define versions to align with those in cloud to ensure that we are using the same versions across cloud. I've also added missing versions and removed a couple of versions that are unnecessary, as they are not included in cloud (I did confirm that the runtime DB doesn't have any workspaces using those versions, just to be thorough).