### PR TITLE
exploring approaches to reduce memory usage

### DIFF
--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -13,7 +13,7 @@ class StateController(object):
 
         self.path = filesystem_service.get_root_path(self.state_id)
         self.serialize_path = filesystem_service.get_path(
-            self.state_id, "manifest.msgpack"
+            self.state_id, "target", "partial_parse.msgpack"
         )
         self.manifest = self.load_manifest(self.serialize_path)
 


### PR DESCRIPTION
Exploration. Let's talk before merging ;)

Big ideas:
 - don't write our own manifest, use the partial-parse one emitted by Core
 - shrink event history buffer
 - turn _off_ partial parsing (this appears to improve memory usage)

Memory profiling:
- left: current behavior on `main`
- right: behavior for the diff in this PR
- the big difference is that we only call `manifest.to_msgpack()` once now, not twice

<img width="2427" alt="Screen Shot 2022-09-21 at 4 23 54 PM" src="https://user-images.githubusercontent.com/1541139/191616668-7993db33-fd52-4556-9ba6-ec2007835f0a.png">
