### PR TITLE
Improve error messages; fix errant 500 error

### DIFF
--- a/dbt_server/exceptions.py
+++ b/dbt_server/exceptions.py
@@ -25,4 +25,8 @@ class StateNotFoundException(InvalidRequestException):
 
 
 class dbtCoreCompilationException(InvalidRequestException):
-    pass
+    @classmethod
+    def from_exc(cls, e):
+        original_message = getattr(e, 'msg', str(e))
+        msg = f"dbt Error: {original_message}"
+        return cls(msg)

--- a/dbt_server/helpers.py
+++ b/dbt_server/helpers.py
@@ -7,10 +7,10 @@ def extract_compiled_code_from_node(result_node_dict):
     # dbt versions < 1.3 use `compiled_sql`, but this has been changed
     # to `compiled_code` in dbt-core v1.3
     compiled_code = result_node_dict.get("compiled_code", None)
-    if not compiled_code:
+    if compiled_code is None:
         compiled_code = result_node_dict.get("compiled_sql", None)
 
-    if not compiled_code:
+    if compiled_code is None:
         msg = "Failed to find compiled_sql or compiled_code in compiled node result"
         raise InternalException(msg)
 

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -173,7 +173,7 @@ def compile_sql(manifest, project_path, sql):
         logger.error(
             f"Failed to compile sql at {project_path}. Compilation Error: {repr(e)}"
         )
-        raise dbtCoreCompilationException(e)
+        raise dbtCoreCompilationException.from_exc(e)
 
     if type(result) != RemoteCompileResult:
         # Theoretically this shouldn't happen-- handling just in case

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -198,7 +198,7 @@ async def configuration_exception_handler(
     request: Request, exc: InvalidConfigurationException
 ):
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
+    exc_str = str(exc)
     logger.error(f"Request to {request.url} failed validation: {exc_str}")
     content = {"status_code": status_code, "message": exc_str, "data": None}
     return JSONResponse(content=content, status_code=status_code)
@@ -207,7 +207,7 @@ async def configuration_exception_handler(
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
-    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
+    exc_str = str(exc)
     logger.error(f"Request to {request.url} failed validation: {exc_str}")
     content = {"status_code": status_code, "message": exc_str, "data": None}
     return JSONResponse(content=content, status_code=status_code)
@@ -216,7 +216,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 @app.exception_handler(InternalException)
 async def unhandled_internal_error(request: Request, exc: InternalException):
     status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
+    exc_str = str(exc)
     logger.error(f"Request to {request.url} failed with an internal error: {exc_str}")
 
     content = {"status_code": status_code, "message": exc_str, "data": None}
@@ -231,7 +231,7 @@ async def handled_dbt_error(request: Request, exc: InvalidRequestException):
     else:
         status_code = status.HTTP_400_BAD_REQUEST
 
-    exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
+    exc_str = str(exc)
     logger.error(f"Request to {request.url} was invalid: {exc_str}")
 
     content = {"status_code": status_code, "message": exc_str, "data": None}


### PR DESCRIPTION
**Note: going to see if we can make this kind of change in Core, as i think that's a better home for this kind of logic...**

Two changes here:
1. Improving (some) error messages raised by Core
2. Convert 500 --> 400 by differentiating between None and and empty string when returning compiled SQL

## Error message diff

Big idea here: the `resource_type`, `unique_id`, `path`, and `name` of SqlOperation nodes are often included in exception messages in Core. SqlOperation properties are pretty jank/confusing, and tend to look like:
 - resource_type: `Sql Operation`
 - unique_id: `sql operation.demo_data.query`
 - path: `from remote system.sql` (there isn't _actually_ a path, but still, this stinks)
 - name: `name` (it's hardcoded as `name`!! PR to make it configurable here https://github.com/dbt-labs/dbt-core/pull/5921)

Most exceptions in dbt follow the format:
```
Compilation Error in [resource_type] [name]
[Error]
```

Errors from dbt Core that pertain to Sql Operations (eg. compile queries) tend to look like:
```
Compilation Error in sql operation name (from remote system.sql)
unexpected '}'   line 1   {{ 1 + 1}
```

I think that `sql operation name (from remote system.sql)` is possibly the most confusing fragment of an error message that I've ever seen, so trying to change that here 😓 . Note that this PR also removes logic that replaces newlines with spaces. I think having separate lines for these error messages makes them a lot more intelligible (especially if there is a stack trace for macro calls), but I'm open to changing that back if anyone has alternative thoughts or opinions. Practical examples below! 

### Syntax errors
**before**
```
Compilation Error in sql operation name (from remote system.sql) unexpected '}'   line 1   {{ 1 + 1}
```

**After**
```
dbt Error: unexpected '}'
  line 1
    {{ 1 + 1}
```

### Ref not found errors
These are better than before, but still not ideal. dbt is trying to tell us that our sql operation node (named `Sql Operation 'sql operation.demo_data.query' (from remote system.sql)`) depends on a node called `badmodel`

**Before**
```
Compilation Error in sql operation query (from remote system.sql) Sql Operation 'sql operation.demo_data.query' (from remote system.sql) depends on a node named 'badmodel' which was not found
```

**After**
```
dbt Error: Sql Operation 'sql operation.demo_data.name' (from remote system.sql) depends on a node named 'badmodel' which was not found
```

### Macro stack traces
**Before**
TODO

**After**
TODO