### PR TITLE
Checks for profile name in args and env vars

### DIFF
--- a/dbt_server/helpers.py
+++ b/dbt_server/helpers.py
@@ -1,4 +1,6 @@
+import os
 from dbt_server.exceptions import InternalException
+from pydantic import BaseModel
 
 
 def extract_compiled_code_from_node(result_node_dict):
@@ -15,3 +17,17 @@ def extract_compiled_code_from_node(result_node_dict):
         raise InternalException(msg)
 
     return compiled_code
+
+
+def set_profile_name(args=None):
+    # If no profile name is passed in args, we will attempt to set it from env vars
+    # If no profile is set, dbt will default to reading from dbt_project.yml
+    if args and args.profile:
+        return args
+    if os.getenv("DBT_PROFILE_NAME"):
+        if args == None:
+            class Args(BaseModel):
+                profile: str = None
+            args = Args()
+        args.profile = os.getenv("DBT_PROFILE_NAME")
+    return args

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -44,7 +44,7 @@ from dbt_server.exceptions import (
     dbtCoreCompilationException,
     UnsupportedQueryException,
 )
-
+from dbt_server.helpers import set_profile_name
 
 # Temporary default to match dbt-cloud behavior
 PROFILE_NAME = os.getenv("DBT_PROFILE_NAME", "user")
@@ -117,6 +117,7 @@ def get_sql_parser(config, manifest):
 @tracer.wrap
 def create_dbt_config(project_path, args=None):
     try:
+        args = set_profile_name(args)
         # This needs a lock to prevent two threads from mutating an adapter concurrently
         with CONFIG_GLOBAL_LOCK:
             return dbt_get_dbt_config(project_path, args)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This adds functionality to allow users to supply a credentials `profile` in the following hierarchy:
* Via cli arg --profile
* Using the env var `DBT_PROFILE_NAME`
* The value set for `profile` in the `dbt_project.yml`

If the cli arg is not set, it will progress to checking the env, and so on.

This will allow clients of the dbt-server multiple methods to override this value-- including the runtime gateway-- without having to change in the `dbt_project.yml` every time

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
