### PR TITLE
Add what is dbt server to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # dbt-server
 
+## What is dbt-server?
+dbt Server wraps dbt Core in a persistent server that is responsible for handling RESTful API requests for dbt operations. It’s a thin interface that is primarily responsible for performance and reliability in production environments.
+
 ## 👩‍💻 Set up your development environment
 
 ### 🐍 Install Python


### PR DESCRIPTION
## What is this PR?
This is a:
- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
The README is too focused on how to deploy the server, as opposed to what it is or why it would be necessary. 

Contrast with [Core's readme](https://github.com/dbt-labs/dbt-core/blob/main/README.md) or [dbt-docs](https://github.com/dbt-labs/dbt-docs) which have pitches on what their code _does_ and how to get started using it. Core in particular has all of the deployment and contribution directions in a dedicated [contributing](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) file.

This PR is woefully inadequate to solve that problem, but it's a start! (stolen from the 0.1.0 release description).
