### PR TITLE
Fix API docs

### DIFF
--- a/.changes/unreleased/Fixes-20221104-150715.yaml
+++ b/.changes/unreleased/Fixes-20221104-150715.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix API docs site
+time: 2022-11-04T15:07:15.401922-04:00
+custom:
+  Author: joemirizio
+  Issue: "114"
+  PR: "116"

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -345,61 +345,55 @@ async def list_resources(args: ListArgs):
     )
 
 
-@app.post("/run-async")
+@app.post("/run-async", response_model=schemas.Task)
 async def run_models_async(
     args: RunArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.run_async(background_tasks, db, args)
 
 
-@app.post("/test-async")
+@app.post("/test-async", response_model=schemas.Task)
 async def test_async(
     args: TestArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.test_async(background_tasks, db, args)
 
 
-@app.post("/seed-async")
+@app.post("/seed-async", response_model=schemas.Task)
 async def seed_async(
     args: SeedArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.seed_async(background_tasks, db, args)
 
 
-@app.post("/build-async")
+@app.post("/build-async", response_model=schemas.Task)
 async def build_async(
     args: BuildArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.build_async(background_tasks, db, args)
 
 
-@app.post("/snapshot-async")
+@app.post("/snapshot-async", response_model=schemas.Task)
 async def snapshot_async(
     args: SnapshotArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.snapshot_async(background_tasks, db, args)
 
 
-@app.post("/run-operation-async")
+@app.post("/run-operation-async", response_model=schemas.Task)
 async def run_operation_async(
     args: RunOperationArgs,
     background_tasks: BackgroundTasks,
-    response_model=schemas.Task,
     db: Session = Depends(crud.get_db),
 ):
     return task_service.run_operation_async(background_tasks, db, args)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Fixes #114 by moving the `response_model` from the args to the decorator. The docs now display properly when navigating to `/docs`.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md


