### PR TITLE
Passes target name through StateController for each config creation

### DIFF
--- a/.changes/unreleased/Fixes-20221129-082728.yaml
+++ b/.changes/unreleased/Fixes-20221129-082728.yaml
@@ -1,0 +1,9 @@
+kind: Fixes
+body: Passes args through parse, sql compile and preview endpoints to the StateController;
+  updates the StateController methods to accept args to be passed to parse function
+  in lib.py that already accepts args.
+time: 2022-11-29T08:27:28.370561-06:00
+custom:
+  Author: racheldaniel
+  Issue: "123"
+  PR: "122"

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -16,8 +16,10 @@ from dbt_server.exceptions import StateNotFoundException
 models.Base.metadata.create_all(bind=engine)
 dbt_service.disable_tracking()
 
+
 class ConfigArgs(BaseModel):
-   target: Optional[str] = None
+    target: Optional[str] = None
+
 
 def startup_cache_initialize():
     """
@@ -50,7 +52,7 @@ def startup_cache_initialize():
             f"[STARTUP] Specified latest state not found - not loading manifest (state_id={latest_state_id})"
         )
         return
-    
+
     target_name = os.environ.get("__DBT_TARGET_NAME", "")
     config_args = ConfigArgs(target=target_name)
 

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -1,4 +1,7 @@
 # Need to run this as early in the server's startup as possible
+import os
+from typing import Optional
+from pydantic import BaseModel
 from dbt_server import tracer  # noqa
 
 from dbt_server import models
@@ -13,6 +16,8 @@ from dbt_server.exceptions import StateNotFoundException
 models.Base.metadata.create_all(bind=engine)
 dbt_service.disable_tracking()
 
+class ConfigArgs(BaseModel):
+   target: Optional[str] = None
 
 def startup_cache_initialize():
     """
@@ -45,11 +50,16 @@ def startup_cache_initialize():
             f"[STARTUP] Specified latest state not found - not loading manifest (state_id={latest_state_id})"
         )
         return
+    
+    target_name = os.environ.get("__DBT_TARGET_NAME", "")
+    config_args = ConfigArgs(target=target_name)
 
     source_path = filesystem_service.get_root_path(latest_state_id)
     manifest_size = filesystem_service.get_size(manifest_path)
+    config = dbt_service.create_dbt_config(source_path, config_args)
+
     LAST_PARSED.set_last_parsed_manifest(
-        latest_state_id, manifest, source_path, manifest_size
+        latest_state_id, manifest, manifest_size, config
     )
 
     logger.info(f"[STARTUP] Cached manifest in memory (state_id={latest_state_id})")

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -67,7 +67,7 @@ class StateController(object):
 
     @classmethod
     @tracer.wrap
-    def from_parts(cls, state_id, manifest, source_path, manifest_size, args):
+    def from_parts(cls, state_id, manifest, source_path, manifest_size, args=None):
         config = dbt_service.create_dbt_config(source_path, args)
         parser = dbt_service.get_sql_parser(config, manifest)
 
@@ -94,7 +94,7 @@ class StateController(object):
 
     @classmethod
     @tracer.wrap
-    def parse_from_source(cls, state_id, parse_args):
+    def parse_from_source(cls, state_id, parse_args=None):
         """
         Loads a manifest from source code in a specified directory based on the
         provided state_id. This method will cache the parsed manifest in memory
@@ -109,7 +109,7 @@ class StateController(object):
 
     @classmethod
     @tracer.wrap
-    def load_state(cls, state_id, args):
+    def load_state(cls, state_id, args=None):
         """
         Loads a manifest given a state_id from an in-memory cache if present,
         or from disk at a location specified by the state_id argument. The

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -20,13 +20,13 @@ class CachedManifest:
     config: Optional[Any] = None
     parser: Optional[Any] = None
 
-    def set_last_parsed_manifest(self, state_id, manifest, project_path, manifest_size):
+    def set_last_parsed_manifest(self, state_id, manifest, manifest_size, config):
         with MANIFEST_LOCK:
             self.state_id = state_id
             self.manifest = manifest
             self.manifest_size = manifest_size
+            self.config = config
 
-            self.config = dbt_service.create_dbt_config(project_path)
             self.parser = dbt_service.get_sql_parser(self.config, self.manifest)
 
     def lookup(self, state_id):
@@ -67,8 +67,8 @@ class StateController(object):
 
     @classmethod
     @tracer.wrap
-    def from_parts(cls, state_id, manifest, source_path, manifest_size):
-        config = dbt_service.create_dbt_config(source_path)
+    def from_parts(cls, state_id, manifest, source_path, manifest_size, args):
+        config = dbt_service.create_dbt_config(source_path, args)
         parser = dbt_service.get_sql_parser(config, manifest)
 
         return cls(
@@ -105,11 +105,11 @@ class StateController(object):
         manifest = dbt_service.parse_to_manifest(source_path, parse_args)
 
         logger.info(f"Done parsing from source (state_id={state_id})")
-        return cls.from_parts(state_id, manifest, source_path, 0)
+        return cls.from_parts(state_id, manifest, source_path, 0, parse_args)
 
     @classmethod
     @tracer.wrap
-    def load_state(cls, state_id):
+    def load_state(cls, state_id, args):
         """
         Loads a manifest given a state_id from an in-memory cache if present,
         or from disk at a location specified by the state_id argument. The
@@ -139,7 +139,7 @@ class StateController(object):
         manifest_size = filesystem_service.get_size(manifest_path)
 
         source_path = filesystem_service.get_root_path(state_id)
-        return cls.from_parts(state_id, manifest, source_path, manifest_size)
+        return cls.from_parts(state_id, manifest, source_path, manifest_size, args)
 
     @tracer.wrap
     def serialize_manifest(self):
@@ -169,5 +169,5 @@ class StateController(object):
     def update_cache(self):
         logger.info(f"Updating cache (state_id={self.state_id})")
         LAST_PARSED.set_last_parsed_manifest(
-            self.state_id, self.manifest, self.root_path, self.manifest_size
+            self.state_id, self.manifest, self.manifest_size, self.config
         )

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -190,6 +190,7 @@ class RunOperationArgs(BaseModel):
 class SQLConfig(BaseModel):
     state_id: Optional[str] = None
     sql: str
+    target: Optional[str] = None
 
 
 @app.exception_handler(InvalidConfigurationException)
@@ -407,7 +408,7 @@ async def run_operation_async(
 
 @app.post("/preview")
 async def preview_sql(sql: SQLConfig):
-    state = StateController.load_state(sql.state_id)
+    state = StateController.load_state(sql.state_id, sql)
     result = state.execute_query(sql.sql)
     compiled_code = helpers.extract_compiled_code_from_node(result)
 
@@ -426,7 +427,7 @@ async def preview_sql(sql: SQLConfig):
 
 @app.post("/compile")
 def compile_sql(sql: SQLConfig):
-    state = StateController.load_state(sql.state_id)
+    state = StateController.load_state(sql.state_id, sql)
     result = state.compile_query(sql.sql)
     compiled_code = helpers.extract_compiled_code_from_node(result)
 

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -65,17 +65,16 @@ class CompilationInterfaceTests(unittest.TestCase):
                 json={
                     "sql": source_query,
                     "state_id": state_id,
-                    "target": "new_target"
+                    "target": "new_target",
                 },
             )
 
             state_mock.assert_called_once_with(
                 state_id,
                 SQLConfig(
-                    state_id='goodid',
-                    sql='select {{ 1 + 1 }}',
-                    target="new_target"
-                ))
+                    state_id="goodid", sql="select {{ 1 + 1 }}", target="new_target"
+                ),
+            )
             query_mock.assert_called_once_with(source_query)
             assert response.status_code == 200
 
@@ -106,10 +105,11 @@ class CompilationInterfaceTests(unittest.TestCase):
             state.assert_called_once_with(
                 state_id,
                 SQLConfig(
-                    state_id='badid',
+                    state_id="badid",
                     sql="select {{ exceptions.raise_compiler_error('bad')}}",
-                    target=None
-                ))
+                    target=None,
+                ),
+            )
             assert response.status_code == 400
 
             expected = {
@@ -181,7 +181,9 @@ class CompilationInterfaceTests(unittest.TestCase):
             "dbt_server.services.dbt_service",
             get_sql_parser=Mock(),
         ):
-            cached.set_last_parsed_manifest("def456", new_manifest_mock, 1024, new_config_mock)
+            cached.set_last_parsed_manifest(
+                "def456", new_manifest_mock, 1024, new_config_mock
+            )
             assert cached.state_id == "def456"
             assert cached.manifest is not None
             assert cached.manifest_size == 1024

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -65,6 +65,7 @@ class CompilationInterfaceTests(unittest.TestCase):
                 json={
                     "sql": source_query,
                     "state_id": state_id,
+                    "target": "new_target"
                 },
             )
 
@@ -73,7 +74,7 @@ class CompilationInterfaceTests(unittest.TestCase):
                 SQLConfig(
                     state_id='goodid',
                     sql='select {{ 1 + 1 }}',
-                    target=None
+                    target="new_target"
                 ))
             query_mock.assert_called_once_with(source_query)
             assert response.status_code == 200
@@ -161,7 +162,7 @@ class CompilationInterfaceTests(unittest.TestCase):
             assert cached.state_id == "abc123"
             assert cached.manifest is not None
             assert cached.manifest_size == 512
-            assert cached.config is not None
+            assert cached.config == config_mock
             assert cached.parser is not None
 
         assert cached.lookup(None) is not None
@@ -184,7 +185,7 @@ class CompilationInterfaceTests(unittest.TestCase):
             assert cached.state_id == "def456"
             assert cached.manifest is not None
             assert cached.manifest_size == 1024
-            assert cached.config is not None
+            assert cached.config == new_config_mock
             assert cached.parser is not None
 
         assert cached.lookup(None) is not None

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -142,8 +142,6 @@ class CompilationInterfaceTests(unittest.TestCase):
         assert cached.manifest is None
         assert cached.manifest_size is None
 
-        path = "working-dir/state-abc123/"
-
         cache_miss = cached.lookup("abc123")
         assert cache_miss is None
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Passes args through parse, sql compile and preview endpoints to the StateController; updates the StateController methods to accept args to be passed to parse function in lib.py that already accepts args.

This is part of a larger effort to accept custom targets for the Semantic Layer, but this PR does not include breaking changes and can be merged before the other PRs if necessary.

**Other PRS**
- [runtime-gateway](https://github.com/dbt-labs/runtime-gateway/pull/186)
- [workspace-controller](https://github.com/dbt-labs/workspace-controller/pull/96)
- [dbt-cloud](https://github.com/dbt-labs/dbt-cloud/pull/5949)
- [cloud-ui](https://github.com/dbt-labs/cloud-ui/pull/921)
- [dimsum](https://github.com/dbt-labs/dimsum/pull/101)

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models
- [x] I have added an entry to CHANGELOG.md
