### PR TITLE
Upgrade FastAPI version in requirements.txt and add httpx to dev-requirements.txt to resolve error handling issue with underlying FastAPI dependency

### DIFF
--- a/.changes/unreleased/Under the Hood-20221221-112702.yaml
+++ b/.changes/unreleased/Under the Hood-20221221-112702.yaml
@@ -1,0 +1,8 @@
+kind: Under the Hood
+body: Upgrade FastAPI version in requirements.txt and add httpx to dev-requirements.txt
+  to resolve error handling issue with underlying FastAPI dependency
+time: 2022-12-21T11:27:02.990803-08:00
+custom:
+  Author: jenniferjsmmiller
+  Issue: "599"
+  PR: "149"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 black==22.6.0
 flake8==5.0.0
+httpx==0.23.0
 ipdb==0.13.9
 pytest==7.1.2
 pre-commit==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SQLAlchemy==1.4.23
 diff-match-patch==20200713
-fastapi==0.68.1
+fastapi==0.88.0
 python-json-logger==2.0.4
 sse-starlette==0.9.0
 gunicorn==20.1.0


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Right now - on the current version of FastAPI that dbt-server uses - when an error occurs after a request has been made to an async endpoint, the actual error message gets obfuscated by an underlying dependency that FastAPI uses, Starlette. Here's an example of the issue we're seeing where the actual error gets overwritten by Starlette:

```
2022-12-08 12:07:53,666 - [47226] asyncio - ERROR - Task exception was never retrieved
future: <Task finished name='Task-4' coro=<BaseHTTPMiddleware.call_next.<locals>.coro() done, defined at /Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/middleware/base.py:36> exception=RuntimeError('Caught handled exception, but response already started.')>
Traceback (most recent call last):
  File "/Users/racheldaniel/git/dbt-server/dbt_server/services/filesystem_service.py", line 51, in read_serialized_manifest
    with open(path, "rb") as fh:
FileNotFoundError: [Errno 2] No such file or directory: './working-dir/state-8179bd556d9fd718777ae6782d3/manifest.msgpack'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/routing.py", line 580, in __call__
    await route.handle(scope, receive, send)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/routing.py", line 241, in handle
    await self.app(scope, receive, send)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/routing.py", line 55, in app
    await response(scope, receive, send)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/responses.py", line 146, in __call__
    await self.background()
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/background.py", line 35, in __call__
    await task()
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/background.py", line 20, in __call__
    await run_in_threadpool(self.func, *self.args, **self.kwargs)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/concurrency.py", line 40, in run_in_threadpool
    return await loop.run_in_executor(None, func, *args)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/racheldaniel/git/dbt-server/dbt_server/services/task_service.py", line 26, in run_task
    manifest = dbt_service.deserialize_manifest(serialize_path)
  File "/Users/racheldaniel/git/dbt-server/dbt_server/tracer.py", line 42, in no_op
    return func(*args, **kwargs)
  File "/Users/racheldaniel/git/dbt-server/dbt_server/services/dbt_service.py", line 161, in deserialize_manifest
    manifest_packed = filesystem_service.read_serialized_manifest(serialize_path)
  File "/Users/racheldaniel/git/dbt-server/dbt_server/tracer.py", line 42, in no_op
    return func(*args, **kwargs)
  File "/Users/racheldaniel/git/dbt-server/dbt_server/services/filesystem_service.py", line 54, in read_serialized_manifest
    raise StateNotFoundException(e)
dbt_server.exceptions.StateNotFoundException: [Errno 2] No such file or directory: './working-dir/state-8179bd556d9fd718777ae6782d3/manifest.msgpack'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/Users/racheldaniel/.pyenv/versions/3.8.13/envs/dbt-server-env/lib/python3.8/site-packages/starlette/exceptions.py", line 86, in __call__
    raise RuntimeError(msg) from exc
RuntimeError: Caught handled exception, but response already started.`
```
While it was originally thought this was an issue with the way our exception handlers we set up, the actual issue is as follows:

Let’s start with the knowledge that at the time the above error vomit is occurring, the client has already received the response from the /run-async endpoint with the task id and additional info. 

What typically happens for these async endpoints is as follows: [request is received] -> [task is added to BackgroundTasks] -> [response is sent] -> [background task runs]. The custom exception handlers we've set up are used in the context of returning a response to the client. To be more explicit, these exception handlers are a part of the request/response lifecycle - exceptions/errors raised do not seem to get routed to them otherwise.  This is why we get this message: Caught handled exception, but response already started.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
