### PR TITLE
Fix profile for async endpoint

### DIFF
--- a/dbt_server/crud.py
+++ b/dbt_server/crud.py
@@ -6,6 +6,7 @@ from . import models, schemas
 
 def get_db():
     db = SessionLocal()
+
     try:
         yield db
     finally:

--- a/dbt_server/crud.py
+++ b/dbt_server/crud.py
@@ -6,7 +6,6 @@ from . import models, schemas
 
 def get_db():
     db = SessionLocal()
-
     try:
         yield db
     finally:

--- a/dbt_server/helpers.py
+++ b/dbt_server/helpers.py
@@ -1,10 +1,5 @@
 import os
 from dbt_server.exceptions import InternalException
-from pydantic import BaseModel
-
-
-class Args(BaseModel):
-    profile: str = None
 
 
 def extract_compiled_code_from_node(result_node_dict):
@@ -23,13 +18,12 @@ def extract_compiled_code_from_node(result_node_dict):
     return compiled_code
 
 
-def set_profile_name(args=None):
-    # If no profile name is passed in args, we will attempt to set it from env vars
-    # If no profile is set, dbt will default to reading from dbt_project.yml
+def get_profile_name(args=None):
+    # If no profile name is passed in args, we will attempt to get it from env vars
+    # If profile is None, dbt will default to reading from dbt_project.yml
     if args and hasattr(args, "profile") and args.profile:
-        return args
-    if os.getenv("DBT_PROFILE_NAME"):
-        if args is None:
-            args = Args()
-        args.profile = os.getenv("DBT_PROFILE_NAME")
-    return args
+        return args.profile
+    env_profile_name = os.getenv("DBT_PROFILE_NAME")
+    if env_profile_name:
+        return env_profile_name
+    return None

--- a/dbt_server/models.py
+++ b/dbt_server/models.py
@@ -1,8 +1,6 @@
 from sqlalchemy import Column, String
 from enum import Enum
-
 from .database import Base
-
 
 class TaskState(str, Enum):
     PENDING = "pending"

--- a/dbt_server/models.py
+++ b/dbt_server/models.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, String
 from enum import Enum
 from .database import Base
 
+
 class TaskState(str, Enum):
     PENDING = "pending"
     RUNNING = "running"

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -13,7 +13,8 @@ from dbt_server.state import LAST_PARSED
 from dbt_server.exceptions import StateNotFoundException
 
 
-models.Base.metadata.create_all(bind=engine)
+models.Base.metadata.create_all(bind=engine, checkfirst=True)
+
 dbt_service.disable_tracking()
 
 

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -13,8 +13,8 @@ from dbt_server.state import LAST_PARSED
 from dbt_server.exceptions import StateNotFoundException
 from sqlalchemy.exc import OperationalError
 
-# The default checkfirst=True should handle this, however we still see a table exists
-# error from time to time
+# The default checkfirst=True should handle this, however we still
+# see a table exists error from time to time
 try:
     models.Base.metadata.create_all(bind=engine, checkfirst=True)
 except OperationalError as err:

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -11,9 +11,14 @@ from dbt_server.views import app
 from dbt_server.logging import DBT_SERVER_LOGGER as logger, configure_uvicorn_access_log
 from dbt_server.state import LAST_PARSED
 from dbt_server.exceptions import StateNotFoundException
+from sqlalchemy.exc import OperationalError
 
-
-models.Base.metadata.create_all(bind=engine, checkfirst=True)
+# The default checkfirst=True should handle this, however we still see a table exists
+# error from time to time
+try:
+    models.Base.metadata.create_all(bind=engine, checkfirst=True)
+except OperationalError as err:
+    logger.debug(f"Handled error when creating database: {str(err)}")
 
 dbt_service.disable_tracking()
 

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -2,7 +2,7 @@ import os
 from dbt_server.services import filesystem_service, dbt_service
 from dbt_server.exceptions import StateNotFoundException
 from dbt_server.logging import DBT_SERVER_LOGGER as logger
-from dbt_server.helpers import set_profile_name
+from dbt_server.helpers import get_profile_name
 from dbt_server import crud, tracer
 from dbt.lib import load_profile_project
 from dbt.cli.main import dbtRunner
@@ -218,7 +218,9 @@ class StateController(object):
         new_command += command
 
         logger.info(f"Running dbt ({task_id}) - deserializing manifest {self.serialize_path}")
-        profile_name = set_profile_name()
+
+        # TODO: If a command contains a --profile flag, how should we access/pass it?
+        profile_name = get_profile_name()
         profile, project = load_profile_project(self.root_path, profile_name)
 
         crud.set_task_running(db, db_task)

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -2,6 +2,7 @@ import os
 from dbt_server.services import filesystem_service, dbt_service
 from dbt_server.exceptions import StateNotFoundException
 from dbt_server.logging import DBT_SERVER_LOGGER as logger
+from dbt_server.helpers import set_profile_name
 from dbt_server import crud, tracer
 from dbt.lib import load_profile_project
 from dbt.cli.main import dbtRunner
@@ -217,8 +218,8 @@ class StateController(object):
         new_command += command
 
         logger.info(f"Running dbt ({task_id}) - deserializing manifest {self.serialize_path}")
-
-        profile, project = load_profile_project(self.root_path, os.getenv("DBT_PROFILE_NAME", "user"),)
+        profile_name = set_profile_name()
+        profile, project = load_profile_project(self.root_path, profile_name)
 
         crud.set_task_running(db, db_task)
 

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -272,5 +272,15 @@ def get_manifest_metadata(state):
     }
 
 
-class Task(BaseModel):
-    task_id: str
+@app.get("/status/{task_id}")
+def get_task_status(
+    task_id: str,
+    db: Session = Depends(crud.get_db),
+):
+    task = crud.get_task(db, task_id)
+    return JSONResponse(
+        status_code=200,
+        content={
+            "status": task.state
+        }
+    )

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -79,6 +79,8 @@ class SQLConfig(BaseModel):
 class dbtCommandArgs(BaseModel):
     command: List[Any]
     state_id: Optional[str]
+    # TODO: Need to handle this differently
+    profile: Optional[str]
 
 
 @app.exception_handler(InvalidConfigurationException)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Tiny fix-- async endpoint should not default to user, that was old dbt-server logic. This helper func should also change eventually, as we won't be handling `args` the same way (if the profile flag is included in the command, it will work the way we are currently using `args` in that helper func)

Also adds a `checkfirst` flag to db creation, as every once in a while the client sees a `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) table tasks already exists` .

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
