### PR TITLE
Add task status callback

### DIFF
--- a/.changes/unreleased/Features-20230206-120426.yaml
+++ b/.changes/unreleased/Features-20230206-120426.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add new task status callback functionality to the async dbt endpoint
+time: 2023-02-06T12:04:26.954999-05:00
+custom:
+  Author: jp-dbt
+  Issue: "165"
+  PR: "164"

--- a/dbt_server/crud.py
+++ b/dbt_server/crud.py
@@ -24,26 +24,13 @@ def create_task(db: Session, task: schemas.Task):
     return db_task
 
 
-def set_task_running(db: Session, task: schemas.Task):
+def set_task_state(db: Session, task: schemas.Task, state: models.TaskState, error: str):
     db_task = get_task(db, task.task_id)
-    db_task.state = models.TaskState.RUNNING
-    db.commit()
-    db.refresh(db_task)
-    return db_task
+    db_task.state = state
 
+    if error:
+        db_task.error = error
 
-def set_task_done(db: Session, task: schemas.Task):
-    db_task = get_task(db, task.task_id)
-    db_task.state = models.TaskState.FINISHED
-    db.commit()
-    db.refresh(db_task)
-    return db_task
-
-
-def set_task_errored(db: Session, task: schemas.Task, error: str):
-    db_task = get_task(db, task.task_id)
-    db_task.state = models.TaskState.ERROR
-    db_task.error = error
     db.commit()
     db.refresh(db_task)
     return db_task

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -301,3 +301,13 @@ def execute_sync_command(command: List, root_path: str, manifest: Any):
 
     dbt = dbtRunner(project, profile, manifest)
     return dbt.invoke(command)
+
+
+def update_task_status(db, db_task, callback_url, status, error):
+    crud.set_task_state(db, db_task, status, error)
+
+    if callback_url:
+        session = requests.Session()
+        session.mount("http://", HTTPAdapter(max_retries=5))
+        session.post(callback_url, json={"task_id": db_task.task_id, "status": status})
+

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -8,6 +8,8 @@ from typing import List, Optional, Any
 import dbt.tracking
 import dbt.lib
 import dbt.adapters.factory
+import requests
+from requests.adapters import HTTPAdapter
 
 from sqlalchemy.orm import Session
 
@@ -49,7 +51,7 @@ from dbt.contracts.sql import (
 from dbt_server.services import filesystem_service
 from dbt_server.logging import DBT_SERVER_LOGGER as logger
 from dbt_server.helpers import get_profile_name
-from dbt_server import crud, tracer
+from dbt_server import crud, tracer, models
 from dbt.lib import load_profile_project
 from dbt.cli.main import dbtRunner
 
@@ -249,6 +251,7 @@ def execute_async_command(
     manifest: Any,
     db: Session,
     state_id: Optional[str] = None,
+    callback_url: Optional[str] = None
 ) -> None:
     db_task = crud.get_task(db, task_id)
     # For commands, only the log file destination directory is sent to --log-path
@@ -270,7 +273,8 @@ def execute_async_command(
     profile_name = get_profile_name()
     profile, project = load_profile_project(root_path, profile_name)
 
-    crud.set_task_running(db, db_task)
+    # crud.set_task_running(db, db_task)
+    update_task_status(db, db_task, callback_url, models.TaskState.RUNNING, None)
 
     logger.info(f"Running dbt ({task_id}) - kicking off task")
 
@@ -278,12 +282,14 @@ def execute_async_command(
         dbt = dbtRunner(project, profile, manifest)
         _, _ = dbt.invoke(new_command)
     except RuntimeException as e:
-        crud.set_task_errored(db, db_task, str(e))
+        # crud.set_task_errored(db, db_task, str(e))
+        update_task_status(db, db_task, callback_url, models.TaskState.ERROR, str(e))
         raise e
 
     logger.info(f"Running dbt ({task_id}) - done")
 
-    crud.set_task_done(db, db_task)
+    # crud.set_task_done(db, db_task)
+    update_task_status(db, db_task, callback_url, models.TaskState.FINISHED, None)
 
 
 @tracer.wrap

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -273,7 +273,6 @@ def execute_async_command(
     profile_name = get_profile_name()
     profile, project = load_profile_project(root_path, profile_name)
 
-    # crud.set_task_running(db, db_task)
     update_task_status(db, db_task, callback_url, models.TaskState.RUNNING, None)
 
     logger.info(f"Running dbt ({task_id}) - kicking off task")
@@ -282,13 +281,11 @@ def execute_async_command(
         dbt = dbtRunner(project, profile, manifest)
         _, _ = dbt.invoke(new_command)
     except RuntimeException as e:
-        # crud.set_task_errored(db, db_task, str(e))
         update_task_status(db, db_task, callback_url, models.TaskState.ERROR, str(e))
         raise e
 
     logger.info(f"Running dbt ({task_id}) - done")
 
-    # crud.set_task_done(db, db_task)
     update_task_status(db, db_task, callback_url, models.TaskState.FINISHED, None)
 
 

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -12,6 +12,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from sqlalchemy.orm import Session
+from urllib3 import Retry
 
 # These exceptions were removed in v1.4
 try:
@@ -310,7 +311,9 @@ def update_task_status(db, db_task, callback_url, status, error):
     crud.set_task_state(db, db_task, status, error)
 
     if callback_url:
+        retries = Retry(total=5, allowed_methods=frozenset(['POST']))
+
         session = requests.Session()
-        session.mount("http://", HTTPAdapter(max_retries=5))
+        session.mount("http://", HTTPAdapter(max_retries=retries))
         session.post(callback_url, json={"task_id": db_task.task_id, "status": status})
 

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -237,9 +237,9 @@ class StateController(object):
         return dbt_service.execute_sql(self.manifest, self.root_path, query)
 
     @tracer.wrap
-    def execute_async_command(self, task_id, command, db) -> None:
+    def execute_async_command(self, task_id, command, db, callback_url) -> None:
         return dbt_service.execute_async_command(
-            command, task_id, self.root_path, self.manifest, db, self.state_id
+            command, task_id, self.root_path, self.manifest, db, self.state_id, callback_url
         )
 
     @tracer.wrap

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -217,12 +217,12 @@ async def dbt_entry_async(
     if db_task:
         raise HTTPException(status_code=400, detail="Task already registered")
 
-    background_tasks.add_task(state.execute_async_command, task_id, args.command, db)
+    background_tasks.add_task(state.execute_async_command, task_id, args.command, db, args.callback_url)
     return crud.create_task(db, task)
 
 
 @app.post("/sync/dbt")
-async def dbt_entry_sync(args: dbtCommandArgs):
+async def dbt_entry_sync(args: DBTCommandArgs):
     # example body: {"command":["list", "--output", "json"]}
     state = StateController.load_state(args)
     # TODO: See what if any useful info is returned when there's no success

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -69,11 +69,12 @@ class SQLConfig(BaseModel):
     profile: Optional[str] = None
 
 
-class dbtCommandArgs(BaseModel):
+class DBTCommandArgs(BaseModel):
     command: List[Any]
     state_id: Optional[str]
     # TODO: Need to handle this differently
     profile: Optional[str]
+    callback_url: Optional[str]
 
 
 @app.exception_handler(InvalidConfigurationException)
@@ -195,7 +196,7 @@ def parse_project(args: ParseArgs):
 
 @app.post("/async/dbt", response_model=schemas.Task)
 async def dbt_entry_async(
-    args: dbtCommandArgs,
+    args: DBTCommandArgs,
     background_tasks: BackgroundTasks,
     db: Session = Depends(crud.get_db),
 ):

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -218,7 +218,17 @@ async def dbt_entry_async(
         raise HTTPException(status_code=400, detail="Task already registered")
 
     background_tasks.add_task(state.execute_async_command, task_id, args.command, db, args.callback_url)
-    return crud.create_task(db, task)
+    created_task = crud.create_task(db, task)
+    return JSONResponse(
+        status_code=200,
+        content={
+            "task_id": created_task.task_id,
+            "state_id": state.state_id,
+            "state": created_task.state,
+            "command": created_task.command,
+            "log_path": created_task.log_path
+        },
+    )
 
 
 @app.post("/sync/dbt")

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -194,7 +194,7 @@ def parse_project(args: ParseArgs):
     )
 
 
-@app.post("/async/dbt", response_model=schemas.Task)
+@app.post("/async/dbt")
 async def dbt_entry_async(
     args: DBTCommandArgs,
     background_tasks: BackgroundTasks,

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -69,7 +69,7 @@ class SQLConfig(BaseModel):
     profile: Optional[str] = None
 
 
-class DBTCommandArgs(BaseModel):
+class DbtCommandArgs(BaseModel):
     command: List[Any]
     state_id: Optional[str]
     # TODO: Need to handle this differently
@@ -196,7 +196,7 @@ def parse_project(args: ParseArgs):
 
 @app.post("/async/dbt")
 async def dbt_entry_async(
-    args: DBTCommandArgs,
+    args: DbtCommandArgs,
     background_tasks: BackgroundTasks,
     db: Session = Depends(crud.get_db),
 ):
@@ -232,7 +232,7 @@ async def dbt_entry_async(
 
 
 @app.post("/sync/dbt")
-async def dbt_entry_sync(args: DBTCommandArgs):
+async def dbt_entry_sync(args: DbtCommandArgs):
     # example body: {"command":["list", "--output", "json"]}
     state = StateController.load_state(args)
     # TODO: See what if any useful info is returned when there's no success

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,3 @@ pytest==7.1.2
 pre-commit==2.20.0
 pre-commit-hooks==4.3.0
 reorder_python_imports==3.8.2
-requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gunicorn==20.1.0
 uvicorn[standard]==0.18.3
 websockets==10.0
 psutil==5.9.2
-requests~=2.26.0
+requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gunicorn==20.1.0
 uvicorn[standard]==0.18.3
 websockets==10.0
 psutil==5.9.2
+requests~=2.26.0

--- a/tests/e2e/test_state.py
+++ b/tests/e2e/test_state.py
@@ -3,7 +3,7 @@ import tempfile
 from unittest import TestCase
 
 from dbt_server.state import StateController, LAST_PARSED
-from dbt_server.views import dbtCommandArgs
+from dbt_server.views import DBTCommandArgs
 from .helpers import profiles_dir
 from .fixtures import Profiles
 import os
@@ -30,7 +30,7 @@ class StateControllerTestCase(TestCase):
     def test_load_state(self):
         # CURRENTLY USING SNOWFLAKE DUE TO DBT VERSION MISMATCH WITH POSTGRES
         with profiles_dir(Profiles.Snowflake):
-            args = dbtCommandArgs(command=["run"], state_id=self.state_id)
+            args = DBTCommandArgs(command=["run"], state_id=self.state_id)
             result = StateController.load_state(args)
 
         assert result.state_id == self.state_id

--- a/tests/e2e/test_state.py
+++ b/tests/e2e/test_state.py
@@ -3,7 +3,7 @@ import tempfile
 from unittest import TestCase
 
 from dbt_server.state import StateController, LAST_PARSED
-from dbt_server.views import DBTCommandArgs
+from dbt_server.views import DbtCommandArgs
 from .helpers import profiles_dir
 from .fixtures import Profiles
 import os
@@ -30,7 +30,7 @@ class StateControllerTestCase(TestCase):
     def test_load_state(self):
         # CURRENTLY USING SNOWFLAKE DUE TO DBT VERSION MISMATCH WITH POSTGRES
         with profiles_dir(Profiles.Snowflake):
-            args = DBTCommandArgs(command=["run"], state_id=self.state_id)
+            args = DbtCommandArgs(command=["run"], state_id=self.state_id)
             result = StateController.load_state(args)
 
         assert result.state_id == self.state_id

--- a/tests/e2e/test_views.py
+++ b/tests/e2e/test_views.py
@@ -60,7 +60,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.DBTCommandArgs(command=["run", "--threads", 1])
+        args = views.DbtCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)
@@ -106,7 +106,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.DBTCommandArgs(command=["run", "--threads", 1])
+        args = views.DbtCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)
@@ -132,7 +132,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         Test that calling the async/dbt endpoint without first calling parse
         results in a properly handled StateNotFoundException
         """
-        args = views.DBTCommandArgs(command=["run", "--threads", 1])
+        args = views.DbtCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
         self.assertEqual(response.status_code, 422)
 
@@ -164,7 +164,7 @@ class TestDbtEntrySync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.DBTCommandArgs(command=["run", "--threads", 1])
+        args = views.DbtCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/sync/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)

--- a/tests/e2e/test_views.py
+++ b/tests/e2e/test_views.py
@@ -60,7 +60,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.dbtCommandArgs(command=["run", "--threads", 1])
+        args = views.DBTCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)
@@ -106,7 +106,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.dbtCommandArgs(command=["run", "--threads", 1])
+        args = views.DBTCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)
@@ -132,7 +132,7 @@ class TestDbtEntryAsync(unittest.TestCase):
         Test that calling the async/dbt endpoint without first calling parse
         results in a properly handled StateNotFoundException
         """
-        args = views.dbtCommandArgs(command=["run", "--threads", 1])
+        args = views.DBTCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/async/dbt", json=args.dict())
         self.assertEqual(response.status_code, 422)
 
@@ -164,7 +164,7 @@ class TestDbtEntrySync(unittest.TestCase):
         state.serialize_manifest()
         state.update_cache()
 
-        args = views.dbtCommandArgs(command=["run", "--threads", 1])
+        args = views.DBTCommandArgs(command=["run", "--threads", 1])
         response = self.client.post("/sync/dbt", json=args.dict())
 
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
- Add a new method to update task status and remove the individual status update methods. This allows us to generically call it upstream
- Accept a callback url as part of the async endpoint request
- Every time task status is updated, send a post request to the callback url with the status. The call will be retried a max of 5 times
- Return the state ID as part of the async endpoint response. This is needed in workspace controller to find the working directory
- Class rename

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
