### PR TITLE
Control server write locations

### DIFF
--- a/dbt_server/database.py
+++ b/dbt_server/database.py
@@ -1,8 +1,10 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from dbt_server.services.filesystem_service import get_db_path
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./sql_app.db"
+
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{get_db_path()}"
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -275,6 +275,13 @@ def execute_async_command(
     logger.info(f"Running dbt ({task_id}) - kicking off task")
 
     try:
+        # Passing a custom target path is not currently working through the
+        # core API. As a result, the target is defaulting to a relative `./dbt_packages`
+        # This chdir action is taken in core for several commands, but not for others,
+        # which can result in a packages dir creation at the app root.
+        # Until custom target paths are supported, this will ensure package folders are created
+        # at the project root.
+        os.chdir(root_path)
         dbt = dbtRunner(project, profile, manifest)
         _, _ = dbt.invoke(new_command)
     except RuntimeException as e:

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -281,9 +281,12 @@ def execute_async_command(
         # which can result in a packages dir creation at the app root.
         # Until custom target paths are supported, this will ensure package folders are created
         # at the project root.
+        last_dir = os.getcwd()
         os.chdir(root_path)
         dbt = dbtRunner(project, profile, manifest)
         _, _ = dbt.invoke(new_command)
+        # Return to app root
+        os.chdir(last_dir)
     except RuntimeException as e:
         crud.set_task_errored(db, db_task, str(e))
         raise e

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -1,13 +1,14 @@
 import os
 import shutil
-from dbt_server.logging import DBT_SERVER_LOGGER as logger
 from dbt_server.exceptions import StateNotFoundException
 from dbt_server import tracer
 
+
 PARTIAL_PARSE_FILE = "partial_parse.msgpack"
+DEFAULT_WORKING_DIR = "./working-dir"
+DATABASE_FILE_NAME = "sql_app.db"
 # This is defined in dbt-core-- dir path is configurable but not filename
 DBT_LOG_FILE_NAME = "dbt.log"
-DEFAULT_WORKING_DIR = "./working-dir"
 
 
 def get_working_dir():
@@ -33,6 +34,13 @@ def get_task_artifacts_path(task_id, state_id=None):
 def get_log_path(task_id, state_id=None):
     artifacts_path = get_task_artifacts_path(task_id, state_id)
     return os.path.join(artifacts_path, DBT_LOG_FILE_NAME)
+
+
+def get_db_path():
+    working_dir = get_working_dir()
+    path = os.path.join(working_dir, DATABASE_FILE_NAME)
+    ensure_dir_exists(path)
+    return path
 
 
 def get_latest_state_file_path():

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -120,7 +120,7 @@ def write_unparsed_manifest_to_disk(state_id, previous_state_id, filedict):
     if previous_state_id and state_id != previous_state_id:
         #  TODO: The target folder is usually created during command runs and won't exist on push/parse
         #  of a new state. It can also be named by env var or flag -- hardcoding as this will change
-        #  with the click API work. This bypasses other use DBT_TARGET_PATH
+        #  with the click API work. This bypasses the DBT_TARGET_PATH env var.
         previous_partial_parse_path = get_path(
             get_root_path(previous_state_id), "target", PARTIAL_PARSE_FILE
         )

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -6,6 +6,7 @@ from dbt_server import tracer
 
 PARTIAL_PARSE_FILE = "partial_parse.msgpack"
 DEFAULT_WORKING_DIR = "./working-dir"
+DEFAULT_TARGET_DIR = "./target"
 DATABASE_FILE_NAME = "sql_app.db"
 # This is defined in dbt-core-- dir path is configurable but not filename
 DBT_LOG_FILE_NAME = "dbt.log"
@@ -15,9 +16,16 @@ def get_working_dir():
     return os.environ.get("__DBT_WORKING_DIR", DEFAULT_WORKING_DIR)
 
 
+def get_target_path():
+    # TODO: The --target-path flag should override this, but doesn't
+    # appear to be working on invoke. When it does, need to revisit
+    # how partial parsing is working
+    return os.environ.get("DBT_TARGET_PATH", DEFAULT_TARGET_DIR)
+
+
 def get_root_path(state_id=None, project_path=None):
     if project_path is not None:
-        return project_path
+        return os.path.abspath(project_path)
     if state_id is None:
         return None
     working_dir = get_working_dir()
@@ -34,6 +42,11 @@ def get_task_artifacts_path(task_id, state_id=None):
 def get_log_path(task_id, state_id=None):
     artifacts_path = get_task_artifacts_path(task_id, state_id)
     return os.path.join(artifacts_path, DBT_LOG_FILE_NAME)
+
+
+def get_partial_parse_path():
+    target_path = get_target_path()
+    return os.path.join(target_path, PARTIAL_PARSE_FILE)
 
 
 def get_db_path():
@@ -107,7 +120,7 @@ def write_unparsed_manifest_to_disk(state_id, previous_state_id, filedict):
     if previous_state_id and state_id != previous_state_id:
         #  TODO: The target folder is usually created during command runs and won't exist on push/parse
         #  of a new state. It can also be named by env var or flag -- hardcoding as this will change
-        #  with the click API work
+        #  with the click API work. This bypasses other use DBT_TARGET_PATH
         previous_partial_parse_path = get_path(
             get_root_path(previous_state_id), "target", PARTIAL_PARSE_FILE
         )

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -82,9 +82,6 @@ class StateController(object):
         self.is_manifest_cached = is_manifest_cached
 
         self.serialize_path = filesystem_service.get_path(root_path, "manifest.msgpack")
-        self.partial_parse_path = filesystem_service.get_path(
-            root_path, "target", filesystem_service.PARTIAL_PARSE_FILE
-        )
 
     @classmethod
     @tracer.wrap
@@ -190,8 +187,9 @@ class StateController(object):
     @tracer.wrap
     def serialize_manifest(self):
         logger.info(f"Serializing manifest to file system ({self.serialize_path})")
+        partial_parse_path = filesystem_service.get_partial_parse_path()
         dbt_service.serialize_manifest(
-            self.manifest, self.serialize_path, self.partial_parse_path
+            self.manifest, self.serialize_path, partial_parse_path
         )
         self.manifest_size = filesystem_service.get_size(self.serialize_path)
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
When this was tested in the IDE, the server's attempts to write to the app root threw permissions errors. This PR ensures that:
- The sqlite db file is written to the working_dir instead of the app root
- dbt Commands are run from the project root, as the target path is not currently fully customizeable through the core API, and this ensures that the target dir defaults to the project root instead of app root

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
