### PR TITLE
Support upstream task IDs

### DIFF
--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -75,6 +75,7 @@ class DbtCommandArgs(BaseModel):
     # TODO: Need to handle this differently
     profile: Optional[str]
     callback_url: Optional[str]
+    task_id: Optional[str]
 
 
 @app.exception_handler(InvalidConfigurationException)
@@ -203,7 +204,11 @@ async def dbt_entry_async(
     # example body: {"state_id": "123", "command":["run", "--threads", 1]}
     state = StateController.load_state(args)
 
-    task_id = str(uuid.uuid4())
+    if args.task_id:
+        task_id = args.task_id
+    else:
+        task_id = str(uuid.uuid4())
+
     log_path = filesystem_service.get_log_path(task_id, state.state_id)
 
     task = schemas.Task(


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
We have a need to manage task IDs in services that use `dbt-server`, so this PR adds support for accepting a task ID as part of the request and using that for the lifecycle of a task.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
