### PR TITLE
Fix bug of not chdir back

### DIFF
--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -291,22 +291,23 @@ def execute_async_command(
 
     logger.info(f"Running dbt ({task_id}) - kicking off task")
 
+    # Passing a custom target path is not currently working through the
+    # core API. As a result, the target is defaulting to a relative `./dbt_packages`
+    # This chdir action is taken in core for several commands, but not for others,
+    # which can result in a packages dir creation at the app root.
+    # Until custom target paths are supported, this will ensure package folders are created
+    # at the project root.
+    dbt_server_root = os.getcwd()
     try:
-        # Passing a custom target path is not currently working through the
-        # core API. As a result, the target is defaulting to a relative `./dbt_packages`
-        # This chdir action is taken in core for several commands, but not for others,
-        # which can result in a packages dir creation at the app root.
-        # Until custom target paths are supported, this will ensure package folders are created
-        # at the project root.
-        last_dir = os.getcwd()
         os.chdir(root_path)
         dbt = dbtRunner(project, profile, manifest)
         _, _ = dbt.invoke(new_command)
-        # Return to app root
-        os.chdir(last_dir)
     except RuntimeException as e:
         update_task_status(db, db_task, callback_url, models.TaskState.ERROR, str(e))
         raise e
+    finally:
+        # Return to dbt server root
+        os.chdir(dbt_server_root)
 
     logger.info(f"Running dbt ({task_id}) - done")
 


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This bug is caught while I'm testing smoke test. The behavior is 
- I create jaffle shop at temp dir.
- Parse + testing...
- Delete jaffle shop.
- Create another jaffle shop at a different temp dir.
- Parse(error)

Spent some times digging into this, I think it's because async end points change the working directory while because I send the wrong commands and exception is thrown, os.chdir(dbt_server_root) won't be executed.

Hence I use finally to ensure it would always be rolled back.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
