### PR TITLE
[Bug] production key removal

### DIFF
--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -50,5 +50,5 @@ runs:
         target: ${{ inputs.docker-file-target }}
         context: ${{ inputs.docker-context }}
         ssh: ${{ inputs.ssh }}
-        tags: ${{ format('{0}, {1}', env.STAGING_VERSION_TAG, env.STAGING_LATEST_TAG) }}
+        tags: ${{ format('{0}, {1}, {2}, {3}', env.STAGING_VERSION_TAG, env.STAGING_LATEST_TAG, env.PRODUCTION_VERSION_TAG, env.PRODUCTION_LATEST_TAG) }}
         push: ${{ inputs.push }}

--- a/.github/actions/registry-login-action/action.yml
+++ b/.github/actions/registry-login-action/action.yml
@@ -1,5 +1,5 @@
 name: "Registry Login Action"
-description: "Logins to development, staging and production registries"
+description: "Logins to staging and production registries"
 inputs:
   staging-registry-endpoint:
     description: "The staging registry where the image should be stored"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,10 @@ jobs:
           # - version: "1.5.0-pre"
           #   package: "dbt-core~=1.5.0b1"
           #   server-branch: "main"
-          - version: "head"
-            package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-            server-branch: "main"
+          # TODO: Cannot test head this way, need adapter package paths as in matrix below as well
+          # - version: "head"
+          #   package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+          #   server-branch: "main"
     steps:
       - name: checkout repo
         if: ${{ matrix.dbt-core.server-branch == github.ref_name || matrix.dbt-core.server-branch == github.event.pull_request.base.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,24 +49,14 @@ jobs:
           - version: "1.4.0-latest"
             package: "dbt-core~=1.4.0"
             server-branch: "0.1.latest"
-          # - version: "1.5.0-pre"
-          #   package: "dbt-core~=1.5.0b1"
-          #   server-branch: "main"
-          # TODO: Cannot test head this way, need adapter package paths as in matrix below as well
-          # - version: "head"
-          #   package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
-          #   server-branch: "main"
     steps:
       - name: checkout repo
-        if: ${{ matrix.dbt-core.server-branch == github.ref_name || matrix.dbt-core.server-branch == github.event.pull_request.base.ref }}
         uses: actions/checkout@v3
       - name: setup python
-        if: ${{ matrix.dbt-core.server-branch == github.ref_name || matrix.dbt-core.server-branch == github.event.pull_request.base.ref }}
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: run tests
-        if: ${{ matrix.dbt-core.server-branch == github.ref_name || matrix.dbt-core.server-branch == github.event.pull_request.base.ref }}
         run: |
           pip install -r requirements.txt -r dev-requirements.txt
           pip install ${{ matrix.dbt-core.package }} dbt-postgres dbt-snowflake


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Removal of these keys caused an ImagePullbackoff error in prod, these were removed for testing and accidentally not returned

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
