### PR TITLE
Prior to performing a parse, ensure that local deps are symlinked in dbt_packages

### DIFF
--- a/.changes/unreleased/Fixes-20230228-180450.yaml
+++ b/.changes/unreleased/Fixes-20230228-180450.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Ensure local deps are properly symlinked in dbt_packages
+time: 2023-02-28T18:04:50.78782-07:00
+custom:
+  Author: peter-bertuglia
+  Issue: "1"
+  PR: "186"

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -5,8 +5,14 @@ from dbt_server.exceptions import StateNotFoundException
 from dbt_server import tracer
 
 
+DEFAULT_WORKING_DIR = os.path.join(os.getcwd(), "working-dir")
+
+
 def get_working_dir():
-    return os.environ.get("__DBT_WORKING_DIR", "./working-dir")
+    return os.environ.get(
+        "__DBT_WORKING_DIR",
+        DEFAULT_WORKING_DIR,
+    )
 
 
 def get_root_path(state_id):

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 import unittest
@@ -5,6 +7,7 @@ import unittest
 from dbt_server.server import app, startup_cache_initialize
 from dbt_server.state import LAST_PARSED
 from dbt_server.exceptions import StateNotFoundException
+from dbt_server.services.filesystem_service import DEFAULT_WORKING_DIR
 
 
 class FakeManifest:
@@ -47,7 +50,9 @@ class StartupCacheTest(unittest.TestCase):
         startup_cache_initialize()
 
         # Make sure manifest is now cached
-        expected_path = "./working-dir/state-abc123/manifest.msgpack"
+        expected_path = os.path.join(
+            DEFAULT_WORKING_DIR, "state-abc123/manifest.msgpack"
+        )
         mock_fs_get_latest_state_id.assert_called_once_with(None)
         mock_fs_get_size.assert_called_once_with(expected_path)
         mock_dbt.assert_called_once_with(expected_path)
@@ -85,7 +90,9 @@ class StartupCacheTest(unittest.TestCase):
 
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
-        mock_dbt.assert_called_once_with("./working-dir/state-abc123/manifest.msgpack")
+        mock_dbt.assert_called_once_with(
+            os.path.join(DEFAULT_WORKING_DIR, "state-abc123/manifest.msgpack")
+        )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None
 
@@ -105,6 +112,8 @@ class StartupCacheTest(unittest.TestCase):
 
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
-        mock_dbt.assert_called_once_with("./working-dir/state-abc123/manifest.msgpack")
+        mock_dbt.assert_called_once_with(
+            os.path.join(DEFAULT_WORKING_DIR, "state-abc123/manifest.msgpack")
+        )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -1,11 +1,13 @@
-from fastapi.testclient import TestClient
+import os
 import unittest
 from unittest.mock import patch, ANY, Mock
 
-from dbt_server.server import app
-from dbt_server.state import StateController, CachedManifest
+from fastapi.testclient import TestClient
 
 from dbt_server.exceptions import dbtCoreCompilationException, StateNotFoundException
+from dbt_server.services.filesystem_service import DEFAULT_WORKING_DIR
+from dbt_server.server import app
+from dbt_server.state import StateController, CachedManifest
 from dbt_server.views import SQLConfig
 
 
@@ -80,7 +82,9 @@ class CompilationInterfaceTests(unittest.TestCase):
 
             expected = {
                 "parsing": state_id,
-                "path": "./working-dir/state-goodid/manifest.msgpack",
+                "path": os.path.join(
+                    DEFAULT_WORKING_DIR, "state-goodid/manifest.msgpack"
+                ),
                 "res": ANY,
                 "compiled_code": compiled_query,
             }

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -7,12 +7,13 @@ from dbt_server.services import filesystem_service
 class FilesystemServiceTest(TestCase):
     def test_dbt_working_dir_default(self):
         self.assertEqual(
-            filesystem_service.get_root_path("abc123"), "./working-dir/state-abc123"
+            filesystem_service.get_root_path("abc123"),
+            os.path.join(filesystem_service.DEFAULT_WORKING_DIR, "state-abc123"),
         )
 
         self.assertEqual(
             filesystem_service.get_latest_state_file_path(),
-            "./working-dir/latest-state-id.txt",
+            os.path.join(filesystem_service.DEFAULT_WORKING_DIR, "latest-state-id.txt"),
         )
 
     @mock.patch.dict(os.environ, {"__DBT_WORKING_DIR": "/opt/code/working-dir"})


### PR DESCRIPTION
Prior to performing a `parse`, ensure that local deps are symlinked in `dbt_packages`

This change has been tested on projects with and without `packages.yml`

## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
