### PR TITLE
Use git+ to install package.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,9 @@ jobs:
       - name: run tests - head
         run: |
           pip install -r requirements.txt -r dev-requirements.txt
-          pip install "https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core"
-          pip install "https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres"
-          pip install "https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake"
+          pip install "git+https://github.com/dbt-labs/dbt-core#egg=dbt-core&subdirectory=core"
+          pip install "git+https://github.com/dbt-labs/dbt-core#egg=dbt-postgres&subdirectory=plugins/postgres"
+          pip install "git+https://github.com/dbt-labs/dbt-snowflake.git#egg=dbt-snowflake"
           pytest
   build-push:
     name: build and push dbt server images
@@ -85,28 +85,28 @@ jobs:
         include:
           - dbt-core:
               version: head
-              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+              package: git+https://github.com/dbt-labs/dbt-core#egg=dbt-core&subdirectory=core
             dbt-database-adapter:
               name: snowflake
-              package: https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake
+              package: git+https://github.com/dbt-labs/dbt-snowflake.git#egg=dbt-snowflake
           - dbt-core:
               version: head
-              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+              package: git+https://github.com/dbt-labs/dbt-core#egg=dbt-core&subdirectory=core
             dbt-database-adapter:
               name: postgres
-              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres
+              package: git+https://github.com/dbt-labs/dbt-core#egg=dbt-postgres&subdirectory=plugins/postgres
           - dbt-core:
               version: head
-              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+              package: git+https://github.com/dbt-labs/dbt-core#egg=dbt-core&subdirectory=core
             dbt-database-adapter:
               name: redshift
-              package: "https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-postgres&subdirectory=plugins/postgres https://github.com/dbt-labs/dbt-redshift/archive/HEAD.tar.gz#egg=dbt-redshift"
+              package: "git+https://github.com/dbt-labs/dbt-core#egg=dbt-postgres&subdirectory=plugins/postgres git+https://github.com/dbt-labs/dbt-redshift#egg=dbt-redshift"
           - dbt-core:
               version: head
-              package: https://github.com/dbt-labs/dbt-core/archive/HEAD.tar.gz#egg=dbt-core&subdirectory=core
+              package: git+https://github.com/dbt-labs/dbt-core#egg=dbt-core&subdirectory=core
             dbt-database-adapter:
               name: bigquery
-              package: https://github.com/dbt-labs/dbt-bigquery/archive/HEAD.tar.gz#egg=dbt-bigquery
+              package: git+https://github.com/dbt-labs/dbt-bigquery#egg=dbt-bigquery
     steps:
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Today pip install "https://github.com/dbt-labs/dbt-snowflake/archive/HEAD.tar.gz#egg=dbt-snowflake" failure cause all CI/CD tests and snowflake image build test are failed.

Asked adaptor team and they suggest to use git+https... to install head package.

Tested locally.

(.venv2) ➜  dbt-server git:(dichen/dev_4) ✗ dbt --version
Core:
  - installed: 1.5.0-b2
  - latest:    1.4.4    - Ahead of latest version!

Plugins:
  - bigquery:  1.5.0b1 - Ahead of latest version!
  - snowflake: 1.5.0b1 - Ahead of latest version!
  - redshift:  1.5.0b1 - Ahead of latest version!
  - postgres:  1.5.0b2 - Ahead of latest version!
  - 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
