### PR TITLE
Adds partial parsing and tests

### DIFF
--- a/.changes/unreleased/Features-20230324-103931.yaml
+++ b/.changes/unreleased/Features-20230324-103931.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Adds partial parsing
+time: 2023-03-24T10:39:31.526957-05:00
+custom:
+  Author: racheldaniel
+  Issue: "1"
+  PR: "196"

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -37,8 +37,8 @@ def startup_cache_initialize():
     if latest_state_id is None:
         logger.info("[STARTUP] No latest state found - not loading manifest into cache")
         return
-
-    manifest_path = filesystem_service.get_path(latest_state_id, "manifest.msgpack")
+    root_path = filesystem_service.get_root_path(latest_state_id)
+    manifest_path = filesystem_service.get_path(root_path, "manifest.msgpack")
     logger.info(
         f"[STARTUP] Loading manifest from file system (state_id={latest_state_id})"
     )

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -200,9 +200,10 @@ def parse_to_manifest(project_path, args):
 
 
 @tracer.wrap
-def serialize_manifest(manifest, serialize_path):
+def serialize_manifest(manifest, serialize_path, partial_parse_path):
     manifest_msgpack = dbt_serialize_manifest(manifest)
     filesystem_service.write_file(serialize_path, manifest_msgpack)
+    filesystem_service.write_file(partial_parse_path, manifest_msgpack)
 
 
 @tracer.wrap

--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -200,10 +200,9 @@ def parse_to_manifest(project_path, args):
 
 
 @tracer.wrap
-def serialize_manifest(manifest, serialize_path, partial_parse_path):
+def serialize_manifest(manifest, serialize_path):
     manifest_msgpack = dbt_serialize_manifest(manifest)
     filesystem_service.write_file(serialize_path, manifest_msgpack)
-    filesystem_service.write_file(partial_parse_path, manifest_msgpack)
 
 
 @tracer.wrap

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -6,6 +6,8 @@ from dbt_server import tracer
 
 
 DEFAULT_WORKING_DIR = os.path.join(os.getcwd(), "working-dir")
+PARTIAL_PARSE_FILE = "partial_parse.msgpack"
+DEFAULT_TARGET_DIR = os.path.join(os.getcwd(), "target")
 
 
 def get_working_dir():
@@ -25,8 +27,8 @@ def get_latest_state_file_path():
     return os.path.join(working_dir, "latest-state-id.txt")
 
 
-def get_path(state_id, *path_parts):
-    return os.path.join(get_root_path(state_id), *path_parts)
+def get_path(*path_parts):
+    return os.path.abspath(os.path.join(*path_parts))
 
 
 @tracer.wrap
@@ -61,14 +63,63 @@ def read_serialized_manifest(path):
 
 
 @tracer.wrap
-def write_unparsed_manifest_to_disk(state_id, filedict):
+def _ensure_dir_exists(path: str):
+    """Check directory of `path` exists, if not make new directory
+    recursively."""
+    dirname = os.path.dirname(path)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+
+@tracer.wrap
+def copy_file(source_path: str, dest_path: str):
+    """Copies file from `source_path` to `dest_path`. The directory of
+    `dest_path` will be created recursively if it doesn't exist."""
+    _ensure_dir_exists(dest_path)
+    shutil.copyfile(source_path, dest_path)
+
+
+@tracer.wrap
+def write_unparsed_manifest_to_disk(
+    state_id: str, previous_state_id: str, filedict: dict
+):
+    """Writes files in `filedict` to root path specified by `state_id`, then
+    copies previous partial parsed msgpack to current root path.
+
+    Args:
+        state_id: required to get root path.
+        previous_state_id: if it's none, we'll skip copy previous partial parsed
+            msgpack to current root path.
+        filedict: key is file name and value is FileInfo."""
     root_path = get_root_path(state_id)
     if os.path.exists(root_path):
         shutil.rmtree(root_path)
 
     for filename, file_info in filedict.items():
-        path = get_path(state_id, filename)
+        path = get_path(root_path, filename)
         write_file(path, file_info.contents)
+
+    if previous_state_id and state_id != previous_state_id:
+        previous_partial_parse_path = get_path(
+            get_root_path(previous_state_id), "target", PARTIAL_PARSE_FILE
+        )
+        new_partial_parse_path = get_path(root_path, "target", PARTIAL_PARSE_FILE)
+        if not os.path.exists(previous_partial_parse_path):
+            return
+        copy_file(previous_partial_parse_path, new_partial_parse_path)
+
+
+def get_target_path():
+    """Returns dbt-core compiled target path."""
+    # TODO: The --target-path flag should override this, but doesn't
+    # appear to be working on invoke. When it does, need to revisit
+    # how partial parsing is working
+    return os.environ.get("DBT_TARGET_PATH", DEFAULT_TARGET_DIR)
+
+
+def get_partial_parse_path():
+    """Returns dbt-core compiled partial parse file."""
+    target_path = get_target_path()
+    return os.path.join(target_path, PARTIAL_PARSE_FILE)
 
 
 @tracer.wrap

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -70,6 +70,7 @@ def _ensure_dir_exists(path: str):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
+
 @tracer.wrap
 def copy_file(source_path: str, dest_path: str):
     """Copies file from `source_path` to `dest_path`. The directory of

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -7,7 +7,6 @@ from dbt_server import tracer
 
 DEFAULT_WORKING_DIR = os.path.join(os.getcwd(), "working-dir")
 PARTIAL_PARSE_FILE = "partial_parse.msgpack"
-DEFAULT_TARGET_DIR = os.path.join(os.getcwd(), "target")
 
 
 def get_working_dir():
@@ -100,6 +99,8 @@ def write_unparsed_manifest_to_disk(
         write_file(path, file_info.contents)
 
     if previous_state_id and state_id != previous_state_id:
+        # There is an env var DBT_TARGET_PATH that can change the target folder
+        # destination in the CLI, but dbt-server 0.1.0 doesn't support this var
         previous_partial_parse_path = get_path(
             get_root_path(previous_state_id), "target", PARTIAL_PARSE_FILE
         )
@@ -107,20 +108,6 @@ def write_unparsed_manifest_to_disk(
         if not os.path.exists(previous_partial_parse_path):
             return
         copy_file(previous_partial_parse_path, new_partial_parse_path)
-
-
-def get_target_path():
-    """Returns dbt-core compiled target path."""
-    # TODO: The --target-path flag should override this, but doesn't
-    # appear to be working on invoke. When it does, need to revisit
-    # how partial parsing is working
-    return os.environ.get("DBT_TARGET_PATH", DEFAULT_TARGET_DIR)
-
-
-def get_partial_parse_path():
-    """Returns dbt-core compiled partial parse file."""
-    target_path = get_target_path()
-    return os.path.join(target_path, PARTIAL_PARSE_FILE)
 
 
 @tracer.wrap

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -1,0 +1,206 @@
+import os
+from dbt_server.exceptions import StateNotFoundException
+from dbt_server.services.filesystem_service import get_working_dir
+from dbt_server.services.filesystem_service import get_partial_parse_path
+from dbt_server.services.filesystem_service import get_latest_state_file_path
+from dbt_server.services.filesystem_service import get_path
+from dbt_server.services.filesystem_service import get_size
+from dbt_server.services.filesystem_service import write_file
+from dbt_server.services.filesystem_service import copy_file
+from dbt_server.services.filesystem_service import read_serialized_manifest
+from dbt_server.services.filesystem_service import write_unparsed_manifest_to_disk
+from dbt_server.services.filesystem_service import get_latest_state_id
+from dbt_server.services.filesystem_service import update_state_id
+from os import makedirs
+from os import environ
+from os import path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest import mock
+
+TEST_STATE_ID = "test_state"
+TEST_PREVIOUS_STATE_ID = "test_previous_state"
+TEST_PATH = "/test_path"
+TEST_PROJECT_PATH = "/tmp"
+TEST_TASK_ID = "task_id"
+TEST_STRING = "test_string"
+TEST_MANIFEST = "test_manifest"
+
+
+class TestFile:
+    pass
+
+
+class TestCachedManifest(TestCase):
+    def tearDown(self) -> None:
+        if "__DBT_WORKING_DIR" in environ:
+            del environ["__DBT_WORKING_DIR"]
+        if "DBT_TARGET_PATH" in environ:
+            del environ["DBT_TARGET_PATH"]
+          
+    def __get_expected_path(self, relative_path):
+        return os.path.join(os.getcwd(), relative_path)
+    
+    def test_get_working_dir(self):
+        # Env
+        environ["__DBT_WORKING_DIR"] = TEST_PATH
+        self.assertEqual(get_working_dir(), TEST_PATH)
+        del environ["__DBT_WORKING_DIR"]
+        # Default
+        expected = self.__get_expected_path("working-dir")
+        self.assertEqual(get_working_dir(), expected)
+
+
+    def test_get_partial_parse_path(self):
+        expected = self.__get_expected_path("target/partial_parse.msgpack")
+        self.assertEqual(get_partial_parse_path(), expected)
+
+    def test_get_latest_state_file_path(self):
+        expected = self.__get_expected_path("working-dir/latest-state-id.txt")
+        self.assertEqual(
+            get_latest_state_file_path(),expected
+        )
+
+    def test_get_path(self):
+        expected = self.__get_expected_path("a/b/c")  
+        self.assertEqual(get_path("a", "b", "c"), expected)
+
+    def test_get_size(self):
+        with TemporaryDirectory() as temp_dir:
+            test_file_path = path.join(temp_dir, "a.txt")
+            with open(test_file_path, "w") as test_file:
+                test_file.write(TEST_STRING)
+            self.assertEqual(get_size(test_file_path), len(TEST_STRING))
+
+    def test_write_file(self):
+        # New directory.
+        with TemporaryDirectory() as temp_dir:
+            test_write_path = path.join(temp_dir, "test_path", "a.txt")
+            write_file(test_write_path, TEST_STRING)
+            with open(test_write_path, "r") as input_file:
+                self.assertEqual(input_file.read(), TEST_STRING)
+
+        # Existing directory.
+        with TemporaryDirectory() as temp_dir:
+            test_write_path = path.join(temp_dir, "a.txt")
+            write_file(test_write_path, TEST_STRING)
+            with open(test_write_path, "r") as input_file:
+                self.assertEqual(input_file.read(), TEST_STRING)
+
+    def test_copy_file(self):
+        with TemporaryDirectory() as temp_dir:
+            source_path = path.join(temp_dir, "a.txt")
+            with open(source_path, "w") as source_file:
+                source_file.write(TEST_STRING)
+            # New directory.
+            dest_path = path.join(temp_dir, "a", "a.txt")
+            copy_file(source_path, dest_path)
+            with open(dest_path, "r") as input_file:
+                self.assertEqual(input_file.read(), TEST_STRING)
+            # Existing directory.
+            dest_path = path.join(temp_dir, "b.txt")
+            copy_file(source_path, dest_path)
+            with open(dest_path, "r") as input_file:
+                self.assertEqual(input_file.read(), TEST_STRING)
+
+    def test_read_serialized_manifest(self):
+        with TemporaryDirectory() as temp_dir:
+            # Found
+            file_path = path.join(temp_dir, "a.txt")
+            with open(file_path, "w") as input_file:
+                input_file.write(TEST_STRING)
+            self.assertEqual(
+                read_serialized_manifest(file_path), TEST_STRING.encode("utf-8")
+            )
+            # Not found.
+            with self.assertRaises(StateNotFoundException) as _:
+                read_serialized_manifest("unknown_path")
+
+    def test_write_unparsed_manifest_to_disk_none_previous_state(self):
+        test_file = TestFile()
+        test_file.contents = TEST_STRING
+        with TemporaryDirectory() as temp_dir:
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            write_unparsed_manifest_to_disk(TEST_STATE_ID, None, {"a.txt": test_file})
+            with open(
+                path.join(temp_dir, f"state-{TEST_STATE_ID}", "a.txt"), "r"
+            ) as output_file:
+                self.assertEqual(output_file.read(), TEST_STRING)
+
+    def test_write_unparsed_manifest_to_disk_same_previous_state(self):
+        test_file = TestFile()
+        test_file.contents = TEST_STRING
+        with TemporaryDirectory() as temp_dir:
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            write_unparsed_manifest_to_disk(
+                TEST_STATE_ID, TEST_STATE_ID, {"a.txt": test_file}
+            )
+            with open(
+                path.join(temp_dir, f"state-{TEST_STATE_ID}", "a.txt"), "r"
+            ) as output_file:
+                self.assertEqual(output_file.read(), TEST_STRING)
+
+    @mock.patch("dbt_server.services.filesystem_service.copy_file")
+    def test_write_unparsed_manifest_to_disk_missing_previous_manifest(
+        self, mock_copy_file
+    ):
+        test_file = TestFile()
+        test_file.contents = TEST_STRING
+        with TemporaryDirectory() as temp_dir:
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            write_unparsed_manifest_to_disk(
+                TEST_STATE_ID, TEST_PREVIOUS_STATE_ID, {"a.txt": test_file}
+            )
+            with open(
+                path.join(temp_dir, f"state-{TEST_STATE_ID}", "a.txt"), "r"
+            ) as output_file:
+                self.assertEqual(output_file.read(), TEST_STRING)
+            mock_copy_file.assert_not_called()
+
+    @mock.patch("dbt_server.services.filesystem_service.copy_file")
+    def test_write_unparsed_manifest_to_disk_copy_previous_manifest(
+        self, mock_copy_file
+    ):
+        test_file = TestFile()
+        test_file.contents = TEST_STRING
+        with TemporaryDirectory() as temp_dir:
+            previous_parse_path = path.join(
+                temp_dir,
+                f"state-{TEST_PREVIOUS_STATE_ID}",
+                "target",
+                "partial_parse.msgpack",
+            )
+            makedirs(path.dirname(previous_parse_path))
+            current_parse_path = path.join(
+                temp_dir, f"state-{TEST_STATE_ID}", "target", "partial_parse.msgpack"
+            )
+            with open(previous_parse_path, "w") as previous_manifest_file:
+                previous_manifest_file.write(TEST_MANIFEST)
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            write_unparsed_manifest_to_disk(
+                TEST_STATE_ID, TEST_PREVIOUS_STATE_ID, {"a.txt": test_file}
+            )
+            with open(
+                path.join(temp_dir, f"state-{TEST_STATE_ID}", "a.txt"), "r"
+            ) as output_file:
+                self.assertEqual(output_file.read(), TEST_STRING)
+        mock_copy_file.assert_called_once_with(previous_parse_path, current_parse_path)
+
+    def test_get_latest_state_id(self):
+        with TemporaryDirectory() as temp_dir:
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            # State id passed in.
+            self.assertEqual(get_latest_state_id(TEST_STATE_ID), TEST_STATE_ID)
+            # Missing local persisted state id.
+            self.assertIsNone(get_latest_state_id(None))
+            # Has local persisted state id.
+            with open(path.join(temp_dir, "latest-state-id.txt"), "w") as state_file:
+                state_file.write(TEST_STATE_ID)
+            self.assertEqual(get_latest_state_id(None), TEST_STATE_ID)
+
+    def test_update_state_id(self):
+        with TemporaryDirectory() as temp_dir:
+            environ["__DBT_WORKING_DIR"] = temp_dir
+            update_state_id(TEST_STATE_ID)
+            with open(path.join(temp_dir, "latest-state-id.txt"), "r") as state_file:
+                self.assertEqual(state_file.read(), TEST_STATE_ID)

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -37,10 +37,10 @@ class TestCachedManifest(TestCase):
             del environ["__DBT_WORKING_DIR"]
         if "DBT_TARGET_PATH" in environ:
             del environ["DBT_TARGET_PATH"]
-          
+
     def __get_expected_path(self, relative_path):
         return os.path.join(os.getcwd(), relative_path)
-    
+
     def test_get_working_dir(self):
         # Env
         environ["__DBT_WORKING_DIR"] = TEST_PATH
@@ -50,19 +50,16 @@ class TestCachedManifest(TestCase):
         expected = self.__get_expected_path("working-dir")
         self.assertEqual(get_working_dir(), expected)
 
-
     def test_get_partial_parse_path(self):
         expected = self.__get_expected_path("target/partial_parse.msgpack")
         self.assertEqual(get_partial_parse_path(), expected)
 
     def test_get_latest_state_file_path(self):
         expected = self.__get_expected_path("working-dir/latest-state-id.txt")
-        self.assertEqual(
-            get_latest_state_file_path(),expected
-        )
+        self.assertEqual(get_latest_state_file_path(), expected)
 
     def test_get_path(self):
-        expected = self.__get_expected_path("a/b/c")  
+        expected = self.__get_expected_path("a/b/c")
         self.assertEqual(get_path("a", "b", "c"), expected)
 
     def test_get_size(self):

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -1,7 +1,6 @@
 import os
 from dbt_server.exceptions import StateNotFoundException
 from dbt_server.services.filesystem_service import get_working_dir
-from dbt_server.services.filesystem_service import get_partial_parse_path
 from dbt_server.services.filesystem_service import get_latest_state_file_path
 from dbt_server.services.filesystem_service import get_path
 from dbt_server.services.filesystem_service import get_size
@@ -49,10 +48,6 @@ class TestCachedManifest(TestCase):
         # Default
         expected = self.__get_expected_path("working-dir")
         self.assertEqual(get_working_dir(), expected)
-
-    def test_get_partial_parse_path(self):
-        expected = self.__get_expected_path("target/partial_parse.msgpack")
-        self.assertEqual(get_partial_parse_path(), expected)
 
     def test_get_latest_state_file_path(self):
         expected = self.__get_expected_path("working-dir/latest-state-id.txt")

--- a/dbt_server/services/task_service.py
+++ b/dbt_server/services/task_service.py
@@ -20,7 +20,7 @@ def run_task(task_name, task_id, args, db):
     db_task = crud.get_task(db, task_id)
 
     path = filesystem_service.get_root_path(args.state_id)
-    serialize_path = filesystem_service.get_path(args.state_id, "manifest.msgpack")
+    serialize_path = filesystem_service.get_path(path, "manifest.msgpack")
     # log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
 
     # log_manager = LogManager(log_path)
@@ -64,7 +64,8 @@ def run_task(task_name, task_id, args, db):
 
 def run_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id, state=TaskState.PENDING, command="dbt run", log_path=log_path
@@ -80,7 +81,8 @@ def run_async(background_tasks, db, args):
 
 def test_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id, state=TaskState.PENDING, command="dbt test", log_path=log_path
@@ -96,7 +98,8 @@ def test_async(background_tasks, db, args):
 
 def seed_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id, state=TaskState.PENDING, command="dbt seed", log_path=log_path
@@ -112,7 +115,8 @@ def seed_async(background_tasks, db, args):
 
 def build_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id, state=TaskState.PENDING, command="dbt build", log_path=log_path
@@ -128,7 +132,8 @@ def build_async(background_tasks, db, args):
 
 def run_operation_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id,
@@ -147,7 +152,8 @@ def run_operation_async(background_tasks, db, args):
 
 def snapshot_async(background_tasks, db, args):
     task_id = str(uuid.uuid4())
-    log_path = filesystem_service.get_path(args.state_id, task_id, "logs.stdout")
+    path = filesystem_service.get_root_path(args.state_id)
+    log_path = filesystem_service.get_path(path, task_id, "logs.stdout")
 
     task = schemas.Task(
         task_id=task_id,

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -63,7 +63,9 @@ class StateController(object):
         self.is_manifest_cached = is_manifest_cached
 
         self.root_path = filesystem_service.get_root_path(state_id)
-        self.serialize_path = filesystem_service.get_path(self.root_path, "manifest.msgpack")
+        self.serialize_path = filesystem_service.get_path(
+            self.root_path, "manifest.msgpack"
+        )
 
     @classmethod
     @tracer.wrap

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -63,7 +63,7 @@ class StateController(object):
         self.is_manifest_cached = is_manifest_cached
 
         self.root_path = filesystem_service.get_root_path(state_id)
-        self.serialize_path = filesystem_service.get_path(state_id, "manifest.msgpack")
+        self.serialize_path = filesystem_service.get_path(self.root_path, "manifest.msgpack")
 
     @classmethod
     @tracer.wrap
@@ -133,7 +133,8 @@ class StateController(object):
             )
 
         # Don't cache on deserialize - that's only for /parse
-        manifest_path = filesystem_service.get_path(state_id, "manifest.msgpack")
+        root_path = filesystem_service.get_root_path(state_id)
+        manifest_path = filesystem_service.get_path(root_path, "manifest.msgpack")
         logger.info(f"Loading manifest from file system ({manifest_path})")
         manifest = dbt_service.deserialize_manifest(manifest_path)
         manifest_size = filesystem_service.get_size(manifest_path)
@@ -143,8 +144,13 @@ class StateController(object):
 
     @tracer.wrap
     def serialize_manifest(self):
+        """Serialize manifest object to local serialized_path and partial parse
+        path, updates manifest_size to the file size."""
         logger.info(f"Serializing manifest to file system ({self.serialize_path})")
-        dbt_service.serialize_manifest(self.manifest, self.serialize_path)
+        partial_parse_path = filesystem_service.get_partial_parse_path()
+        dbt_service.serialize_manifest(
+            self.manifest, self.serialize_path, partial_parse_path
+        )
         self.manifest_size = filesystem_service.get_size(self.serialize_path)
 
     @tracer.wrap

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -147,10 +147,7 @@ class StateController(object):
         """Serialize manifest object to local serialized_path and partial parse
         path, updates manifest_size to the file size."""
         logger.info(f"Serializing manifest to file system ({self.serialize_path})")
-        partial_parse_path = filesystem_service.get_partial_parse_path()
-        dbt_service.serialize_manifest(
-            self.manifest, self.serialize_path, partial_parse_path
-        )
+        dbt_service.serialize_manifest(self.manifest, self.serialize_path)
         self.manifest_size = filesystem_service.get_size(self.serialize_path)
 
     @tracer.wrap


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Adds a hack to allow partial parsing-- on push, if previous state exists, copy the partial parsing file from that state to new state folder so that it can be accessed on parse

Also copies over some of the new filesystem service tests from 0.2.0
## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models
- [x] I have added an entry to CHANGELOG.md
