### PR TITLE
[BUG] Make paths absolute

### DIFF
--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -60,7 +60,7 @@ DBT_LOG_FILE_NAME = "dbt.log"
 def get_working_dir():
     """Returns dbt-server working directory which has dbt-server generated
     files."""
-    return os.environ.get("__DBT_WORKING_DIR", DEFAULT_WORKING_DIR)
+    return os.path.abspath(os.environ.get("__DBT_WORKING_DIR", DEFAULT_WORKING_DIR))
 
 
 def get_target_path():
@@ -68,7 +68,7 @@ def get_target_path():
     # TODO: The --target-path flag should override this, but doesn't
     # appear to be working on invoke. When it does, need to revisit
     # how partial parsing is working
-    return os.environ.get("DBT_TARGET_PATH", DEFAULT_TARGET_DIR)
+    return os.path.abspath(os.environ.get("DBT_TARGET_PATH", DEFAULT_TARGET_DIR))
 
 
 def get_root_path(state_id: str = None, project_path: str = None):
@@ -87,7 +87,7 @@ def get_root_path(state_id: str = None, project_path: str = None):
     if state_id is None:
         return None
     working_dir = get_working_dir()
-    return os.path.join(working_dir, f"state-{state_id}")
+    return os.path.abspath(os.path.join(working_dir, f"state-{state_id}"))
 
 
 def get_task_artifacts_path(task_id, state_id=None):
@@ -97,8 +97,10 @@ def get_task_artifacts_path(task_id, state_id=None):
         state_id: optional, only used for pushed style dbt project."""
     working_dir = get_working_dir()
     if state_id is None:
-        return os.path.join(working_dir, task_id)
-    return os.path.join(working_dir, f"state-{state_id}", task_id)
+        path = os.path.join(working_dir, task_id)
+    else:
+        path = os.path.join(working_dir, f"state-{state_id}", task_id)
+    return os.path.abspath(path)
 
 
 def get_log_path(task_id, state_id=None):
@@ -121,7 +123,7 @@ def get_db_path():
     """Returns local metadata database data file path. Creates directory if
     not existed."""
     working_dir = get_working_dir()
-    path = os.path.join(working_dir, DATABASE_FILE_NAME)
+    path = os.path.abspath(os.path.join(working_dir, DATABASE_FILE_NAME))
     _ensure_dir_exists(path)
     return path
 

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -51,7 +51,7 @@ class TestCachedManifest(TestCase):
         self.assertEqual(get_working_dir(), TEST_PATH)
         del environ["__DBT_WORKING_DIR"]
         # Default
-        self.assertEqual(get_working_dir(), "./working-dir")
+        self.assertEqual(get_working_dir(), path.abspath("./working-dir"))
 
     def test_get_target_path(self):
         # Env
@@ -59,66 +59,66 @@ class TestCachedManifest(TestCase):
         self.assertEqual(get_target_path(), TEST_PATH)
         del environ["DBT_TARGET_PATH"]
         # Default
-        self.assertEqual(get_target_path(), "./target")
+        self.assertEqual(get_target_path(), path.abspath("./target"))
 
     def test_get_root_path(self):
         # None
         self.assertIsNone(get_root_path(None, None))
         # State id
         self.assertEqual(
-            get_root_path(TEST_STATE_ID, None), "./working-dir/state-test_state"
+            get_root_path(TEST_STATE_ID, None), path.abspath("./working-dir/state-test_state")
         )
         # Project path
-        self.assertEqual(get_root_path(None, TEST_PROJECT_PATH), "/tmp")
+        self.assertEqual(get_root_path(None, TEST_PROJECT_PATH), path.abspath("/tmp"))
 
     def test_get_task_artifacts_path(self):
         # Non-state
         self.assertEqual(
-            get_task_artifacts_path(TEST_TASK_ID, None), "./working-dir/task_id"
+            get_task_artifacts_path(TEST_TASK_ID, None), path.abspath("./working-dir/task_id")
         )
         # State id
         self.assertEqual(
             get_task_artifacts_path(TEST_TASK_ID, TEST_STATE_ID),
-            "./working-dir/state-test_state/task_id",
+            path.abspath("./working-dir/state-test_state/task_id"),
         )
 
     def test_get_log_path(self):
         # Non-state
         self.assertEqual(
-            get_log_path(TEST_TASK_ID, None), "./working-dir/task_id/dbt.log"
+            get_log_path(TEST_TASK_ID, None), path.abspath("./working-dir/task_id/dbt.log")
         )
         # State id
         self.assertEqual(
             get_log_path(TEST_TASK_ID, TEST_STATE_ID),
-            "./working-dir/state-test_state/task_id/dbt.log",
+            path.abspath("./working-dir/state-test_state/task_id/dbt.log"),
         )
 
     def test_get_partial_parse_path(self):
-        self.assertEqual(get_partial_parse_path(), "./target/partial_parse.msgpack")
+        self.assertEqual(get_partial_parse_path(), path.abspath("./target/partial_parse.msgpack"))
 
     def test_get_db_path(self):
         # New directory.
         with TemporaryDirectory() as temp_dir:
             test_working_dir = path.join(temp_dir, "test_path")
             environ["__DBT_WORKING_DIR"] = test_working_dir
-            self.assertEqual(get_db_path(), f"{test_working_dir}/sql_app.db")
+            self.assertEqual(get_db_path(), path.abspath(f"{test_working_dir}/sql_app.db"))
             self.assertTrue(path.isdir(test_working_dir))
             del environ["__DBT_WORKING_DIR"]
 
         # Existing directory.
         with TemporaryDirectory() as temp_dir:
             environ["__DBT_WORKING_DIR"] = temp_dir
-            self.assertEqual(get_db_path(), f"{temp_dir}/sql_app.db")
+            self.assertEqual(get_db_path(), path.abspath(f"{temp_dir}/sql_app.db"))
             del environ["__DBT_WORKING_DIR"]
 
     def test_get_latest_state_file_path(self):
         self.assertEqual(
-            get_latest_state_file_path(), "./working-dir/latest-state-id.txt"
+            get_latest_state_file_path(), path.abspath("./working-dir/latest-state-id.txt")
         )
 
     def test_get_latest_project_path_file_path(self):
         self.assertEqual(
-            get_latest_project_path_file_path(), "./working-dir/latest-project-path.txt"
+            get_latest_project_path_file_path(), path.abspath("./working-dir/latest-project-path.txt")
         )
 
     def test_get_path(self):

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -66,7 +66,8 @@ class TestCachedManifest(TestCase):
         self.assertIsNone(get_root_path(None, None))
         # State id
         self.assertEqual(
-            get_root_path(TEST_STATE_ID, None), path.abspath("./working-dir/state-test_state")
+            get_root_path(TEST_STATE_ID, None),
+            path.abspath("./working-dir/state-test_state"),
         )
         # Project path
         self.assertEqual(get_root_path(None, TEST_PROJECT_PATH), path.abspath("/tmp"))
@@ -74,7 +75,8 @@ class TestCachedManifest(TestCase):
     def test_get_task_artifacts_path(self):
         # Non-state
         self.assertEqual(
-            get_task_artifacts_path(TEST_TASK_ID, None), path.abspath("./working-dir/task_id")
+            get_task_artifacts_path(TEST_TASK_ID, None),
+            path.abspath("./working-dir/task_id"),
         )
         # State id
         self.assertEqual(
@@ -85,7 +87,8 @@ class TestCachedManifest(TestCase):
     def test_get_log_path(self):
         # Non-state
         self.assertEqual(
-            get_log_path(TEST_TASK_ID, None), path.abspath("./working-dir/task_id/dbt.log")
+            get_log_path(TEST_TASK_ID, None),
+            path.abspath("./working-dir/task_id/dbt.log"),
         )
         # State id
         self.assertEqual(
@@ -94,14 +97,18 @@ class TestCachedManifest(TestCase):
         )
 
     def test_get_partial_parse_path(self):
-        self.assertEqual(get_partial_parse_path(), path.abspath("./target/partial_parse.msgpack"))
+        self.assertEqual(
+            get_partial_parse_path(), path.abspath("./target/partial_parse.msgpack")
+        )
 
     def test_get_db_path(self):
         # New directory.
         with TemporaryDirectory() as temp_dir:
             test_working_dir = path.join(temp_dir, "test_path")
             environ["__DBT_WORKING_DIR"] = test_working_dir
-            self.assertEqual(get_db_path(), path.abspath(f"{test_working_dir}/sql_app.db"))
+            self.assertEqual(
+                get_db_path(), path.abspath(f"{test_working_dir}/sql_app.db")
+            )
             self.assertTrue(path.isdir(test_working_dir))
             del environ["__DBT_WORKING_DIR"]
 
@@ -113,12 +120,14 @@ class TestCachedManifest(TestCase):
 
     def test_get_latest_state_file_path(self):
         self.assertEqual(
-            get_latest_state_file_path(), path.abspath("./working-dir/latest-state-id.txt")
+            get_latest_state_file_path(),
+            path.abspath("./working-dir/latest-state-id.txt"),
         )
 
     def test_get_latest_project_path_file_path(self):
         self.assertEqual(
-            get_latest_project_path_file_path(), path.abspath("./working-dir/latest-project-path.txt")
+            get_latest_project_path_file_path(),
+            path.abspath("./working-dir/latest-project-path.txt"),
         )
 
     def test_get_path(self):

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -197,7 +197,10 @@ class StateController(object):
             return cls.from_cached(cached)
         # Not in cache - need to go to filesystem to deserialize it
         state_id = filesystem_service.get_latest_state_id(args.state_id)
-        project_path = filesystem_service.get_latest_project_path()
+
+        project_path = args.project_path if hasattr(args, "project_path") else None
+        if not project_path:
+            project_path = filesystem_service.get_latest_project_path()
 
         logger.info(
             f"Manifest cache miss ({_generate_log_details(state_id, project_path)})"

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -72,6 +72,7 @@ class SQLConfig(BaseModel):
 class DbtCommandArgs(BaseModel):
     command: List[Any]
     state_id: Optional[str]
+    project_path: Optional[str] = None
     # TODO: Need to handle this differently
     profile: Optional[str]
     callback_url: Optional[str]
@@ -210,7 +211,6 @@ async def dbt_entry_async(
         task_id = str(uuid.uuid4())
 
     log_path = filesystem_service.get_log_path(task_id, state.state_id)
-
     task = schemas.Task(
         task_id=task_id,
         state=TaskState.PENDING,

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -59,7 +59,9 @@ class StartupCacheTest(DbtCoreTestBase):
         startup_cache_initialize()
 
         # Make sure manifest is now cached
-        expected_path = os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
+        expected_path = os.path.abspath(
+            f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+        )
         mock_fs_get_latest_state_id.assert_called_once_with(None)
         mock_fs_get_size.assert_called_once_with(expected_path)
         mock_dbt.assert_called_once_with(expected_path)
@@ -104,7 +106,9 @@ class StartupCacheTest(DbtCoreTestBase):
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
         mock_dbt.assert_called_once_with(
-            os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
+            os.path.abspath(
+                f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+            )
         )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None
@@ -132,7 +136,9 @@ class StartupCacheTest(DbtCoreTestBase):
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
         mock_dbt.assert_called_once_with(
-            os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
+            os.path.abspath(
+                f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+            )
         )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 
@@ -57,7 +59,7 @@ class StartupCacheTest(DbtCoreTestBase):
         startup_cache_initialize()
 
         # Make sure manifest is now cached
-        expected_path = f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+        expected_path = os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
         mock_fs_get_latest_state_id.assert_called_once_with(None)
         mock_fs_get_size.assert_called_once_with(expected_path)
         mock_dbt.assert_called_once_with(expected_path)
@@ -102,7 +104,7 @@ class StartupCacheTest(DbtCoreTestBase):
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
         mock_dbt.assert_called_once_with(
-            f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+            os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
         )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None
@@ -130,7 +132,7 @@ class StartupCacheTest(DbtCoreTestBase):
         # Make sure manifest is still not cached
         mock_fs.assert_called_once_with(None)
         mock_dbt.assert_called_once_with(
-            f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack"
+            os.path.abspath(f"./working-dir/state-{TEST_LATEST_STATE_ID}/manifest.msgpack")
         )
         assert LAST_PARSED.manifest is None
         assert LAST_PARSED.state_id is None

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -7,7 +7,7 @@ from dbt_server.services import filesystem_service
 class FilesystemServiceTest(TestCase):
     def test_dbt_working_dir_default(self):
         self.assertEqual(
-            filesystem_service.get_root_path("abc123"), "./working-dir/state-abc123"
+            filesystem_service.get_root_path("abc123"), os.path.abspath("./working-dir/state-abc123")
         )
 
         self.assertEqual(

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -7,12 +7,13 @@ from dbt_server.services import filesystem_service
 class FilesystemServiceTest(TestCase):
     def test_dbt_working_dir_default(self):
         self.assertEqual(
-            filesystem_service.get_root_path("abc123"), os.path.abspath("./working-dir/state-abc123")
+            filesystem_service.get_root_path("abc123"),
+            os.path.abspath("./working-dir/state-abc123"),
         )
 
         self.assertEqual(
             filesystem_service.get_latest_state_file_path(),
-            "./working-dir/latest-state-id.txt",
+            os.path.abspath("./working-dir/latest-state-id.txt"),
         )
 
     @mock.patch.dict(os.environ, {"__DBT_WORKING_DIR": "/opt/code/working-dir"})


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Recently a bug was introduced where relative paths would result in incorrect nested artifacts paths like this: `../working-dir/state-{state_id}/working-dir/state-{state_id}/{task_id}`. Making paths absolute corrects this-- unclear whether this has affected prod, but it would only be for users on beta versions of core.

Also adds some logic to the StateController to allow the `/async/dbt` endpoint to be called with a `project_path`, without first calling `/parse`

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
