### PR TITLE
Adds temp method for current IDE usecase

### DIFF
--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -264,7 +264,7 @@ def execute_async_command(
     new_command += command
 
     logger.info(
-        f"Running dbt ({task_id}) - deserializing manifest found at {root_path}"
+        f"Running dbt ({task_id})"
     )
 
     # TODO: this is a tmp solution to set profile_dir to global flags

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -57,8 +57,9 @@ class CachedManifest:
             self.manifest_size = manifest_size
             self.config = config
 
-            # Get parser from config and manifest.
-            self.parser = dbt_service.get_sql_parser(self.config, self.manifest)
+            if self.manifest is not None:
+                # Get parser from config and manifest.
+                self.parser = dbt_service.get_sql_parser(self.config, self.manifest)
 
     def lookup(self, state_id):
         """Checks if required manifest hits cached one, returns None if not
@@ -127,8 +128,10 @@ class StateController(object):
     ):
         """Returns StateController object that stores current dbt core state."""
         config = dbt_service.create_dbt_config(root_path, args)
-        parser = dbt_service.get_sql_parser(config, manifest)
-
+        if manifest is not None:
+            parser = dbt_service.get_sql_parser(config, manifest)
+        else:
+            parser = None
         return cls(
             state_id=state_id,
             project_path=project_path,
@@ -222,6 +225,25 @@ class StateController(object):
 
         return cls._from_parts(
             state_id, project_path, manifest, root_path, manifest_size, args
+        )
+
+    @classmethod
+    @tracer.wrap
+    def load_state_async(cls, args=None):
+        """Temporary slimmed down load state to be used in testing /async/dbt endpoint with only a project_path"""
+        project_path = args.project_path if hasattr(args, "project_path") else None
+        if not project_path:
+            project_path = filesystem_service.get_latest_project_path()
+
+        if project_path is None:
+            raise StateNotFoundException(
+                f"No project_path found {_generate_log_details(None, project_path)}"
+            )
+
+        root_path = filesystem_service.get_root_path(None, project_path)
+
+        return cls._from_parts(
+            None, project_path, None, root_path, 0, args
         )
 
     @tracer.wrap

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -203,7 +203,7 @@ async def dbt_entry_async(
     db: Session = Depends(crud.get_db),
 ):
     # example body: {"state_id": "123", "command":["run", "--threads", 1]}
-    state = StateController.load_state(args)
+    state = StateController.load_state_async(args)
 
     if args.task_id:
         task_id = args.task_id


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
I recently pushed changes to test without first calling `/parse`, but I didn't realize I was only testing in cases where a `manifest.msgpack` already exists. I don't want to mess with the semantic layer usecase here yet, so I took the simplest route and created a special `load_state_async` method that doesn't care about the `manifest.msgpack`, so that the IDE can test calling `parse` through the async endpoint only. 

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
