### PR TITLE
Removes duplication of partial parse

### DIFF
--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -174,10 +174,9 @@ def parse_to_manifest(project_path, args):
 
 
 @tracer.wrap
-def serialize_manifest(manifest, serialize_path, partial_parse_path):
+def serialize_manifest(manifest, serialize_path):
     manifest_msgpack = dbt_serialize_manifest(manifest)
     filesystem_service.write_file(serialize_path, manifest_msgpack)
-    filesystem_service.write_file(partial_parse_path, manifest_msgpack)
 
 
 @tracer.wrap

--- a/dbt_server/services/filesystem_service.py
+++ b/dbt_server/services/filesystem_service.py
@@ -113,12 +113,6 @@ def get_log_path(task_id, state_id=None):
     return os.path.join(artifacts_path, DBT_LOG_FILE_NAME)
 
 
-def get_partial_parse_path():
-    """Returns dbt-core compiled partial parse file."""
-    target_path = get_target_path()
-    return os.path.join(target_path, PARTIAL_PARSE_FILE)
-
-
 def get_db_path():
     """Returns local metadata database data file path. Creates directory if
     not existed."""

--- a/dbt_server/services/filesystem_service_test.py
+++ b/dbt_server/services/filesystem_service_test.py
@@ -4,7 +4,6 @@ from dbt_server.services.filesystem_service import get_target_path
 from dbt_server.services.filesystem_service import get_root_path
 from dbt_server.services.filesystem_service import get_task_artifacts_path
 from dbt_server.services.filesystem_service import get_log_path
-from dbt_server.services.filesystem_service import get_partial_parse_path
 from dbt_server.services.filesystem_service import get_db_path
 from dbt_server.services.filesystem_service import get_latest_state_file_path
 from dbt_server.services.filesystem_service import get_latest_project_path_file_path
@@ -94,11 +93,6 @@ class TestCachedManifest(TestCase):
         self.assertEqual(
             get_log_path(TEST_TASK_ID, TEST_STATE_ID),
             path.abspath("./working-dir/state-test_state/task_id/dbt.log"),
-        )
-
-    def test_get_partial_parse_path(self):
-        self.assertEqual(
-            get_partial_parse_path(), path.abspath("./target/partial_parse.msgpack")
         )
 
     def test_get_db_path(self):

--- a/dbt_server/state.py
+++ b/dbt_server/state.py
@@ -249,10 +249,7 @@ class StateController(object):
         """Serialize manifest object to local serialized_path and partial parse
         path, updates manifest_size to the file size."""
         logger.info(f"Serializing manifest to file system ({self.serialize_path})")
-        partial_parse_path = filesystem_service.get_partial_parse_path()
-        dbt_service.serialize_manifest(
-            self.manifest, self.serialize_path, partial_parse_path
-        )
+        dbt_service.serialize_manifest(self.manifest, self.serialize_path)
         self.manifest_size = filesystem_service.get_size(self.serialize_path)
 
     @tracer.wrap

--- a/dbt_server/state_test.py
+++ b/dbt_server/state_test.py
@@ -344,8 +344,7 @@ class TestStateController(TestCase):
         )
         state_controller.serialize_manifest()
         self.assertEqual(state_controller.manifest_size, TEST_MANIFEST_SIZE)
-        mock_serialize_manifest.assert_called_once_with(
-            TEST_MANIFEST, serialized_path)
+        mock_serialize_manifest.assert_called_once_with(TEST_MANIFEST, serialized_path)
         mock_get_size.assert_called_once_with(serialized_path)
 
     @mock.patch("dbt_server.services.filesystem_service.update_state_id")

--- a/dbt_server/state_test.py
+++ b/dbt_server/state_test.py
@@ -330,19 +330,13 @@ class TestStateController(TestCase):
         mock_create_dbt_config.assert_called_once_with(TEST_ROOT_PATH, args)
 
     @mock.patch(
-        "dbt_server.services.filesystem_service.get_partial_parse_path",
-        return_value=TEST_PARTIAL_PARSE_FILE,
-    )
-    @mock.patch(
         "dbt_server.services.dbt_service.serialize_manifest", return_value=TEST_MANIFEST
     )
     @mock.patch(
         "dbt_server.services.filesystem_service.get_size",
         return_value=TEST_MANIFEST_SIZE,
     )
-    def test_serialize_manifest(
-        self, mock_get_size, mock_serialize_manifest, mock_get_partial_parse_path
-    ):
+    def test_serialize_manifest(self, mock_get_size, mock_serialize_manifest):
 
         serialized_path = f"{TEST_ROOT_PATH}/manifest.msgpack"
         state_controller = StateController(
@@ -350,10 +344,8 @@ class TestStateController(TestCase):
         )
         state_controller.serialize_manifest()
         self.assertEqual(state_controller.manifest_size, TEST_MANIFEST_SIZE)
-        mock_get_partial_parse_path.assert_called_once_with()
         mock_serialize_manifest.assert_called_once_with(
-            TEST_MANIFEST, serialized_path, TEST_PARTIAL_PARSE_FILE
-        )
+            TEST_MANIFEST, serialized_path)
         mock_get_size.assert_called_once_with(serialized_path)
 
     @mock.patch("dbt_server.services.filesystem_service.update_state_id")


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This was removed in server 0.1.0 and I want to remove it here for cleanup and to close out this ticket. The copy that was here (and the function written for it) were extraneous and resulted in multiple `partial_parse.msgpack` files being written out.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
