### PR TITLE
Adds chdir before and after dbt run

### DIFF
--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -35,15 +35,13 @@ from dbt_server.exceptions import (
 from dbt_server.schemas import Invocation
 from dbt_server.schemas import convert_celery_result_to_invocation
 from dbt_server.schemas import get_not_found_invocation
-from dbt_server.flags import DBT_PROJECT_DIRECTORY
 from dbt_worker.app import app as celery_app
-from dbt_worker.tasks import invoke
+from dbt_worker.tasks import append_project_dir, invoke, resolve_project_dir
 from dbt_worker.tasks import is_command_has_log_path
 
 # ORM stuff
 from sqlalchemy.orm import Session
 
-PROJECT_DIR_ARGS = "--project-dir"
 LOG_PATH_ARGS = "--log-path"
 
 # We need to override the EVENT_HISTORY queue to store
@@ -187,43 +185,6 @@ def _list_all_task_ids() -> List[str]:
         raise Exception(
             f"We haven't support {type(celery_app.backend)} in _list_all_task_ids yet."
         )
-
-
-def _is_command_has_project_dir(command: List[str]) -> bool:
-    """Returns true if command has --project-dir args."""
-    # This approach is not 100% accurate but should be good for most cases.
-    return any([PROJECT_DIR_ARGS in item for item in command])
-
-
-def _resolve_project_dir(
-    command: List[str], project_dir: Optional[str]
-) -> Optional[str]:
-    """Resolves request `project_path` and append --project-dir to `command` if
-    needed. Returns resolved project directory or None if can't resolve. Raises
-    AssertionError if --project-dir is found in command and project_dir is
-    provided."""
-
-    is_command_has_project_dir = _is_command_has_project_dir(command)
-    if project_dir and is_command_has_project_dir:
-        raise AssertionError(
-            "Confliction: --project-dir is found in command while project_dir field is also set."
-        )
-    if is_command_has_project_dir or project_dir:
-        return project_dir
-    # Fallback to environment variable.
-    default_project_dir = DBT_PROJECT_DIRECTORY.get()
-    return default_project_dir
-
-
-def _append_project_dir(command: List[str], project_dir: Optional[str]) -> None:
-    """Resolves project directory and appends to command if needed. See
-    PostInvocationRequest.project_dir for more details.
-    """
-    if _is_command_has_project_dir(command):
-        return
-    resolved_project_dir = _resolve_project_dir(command, project_dir)
-    if resolved_project_dir is not None:
-        command.extend([PROJECT_DIR_ARGS, resolved_project_dir])
 
 
 @app.post("/ready")
@@ -427,7 +388,7 @@ class PostInvocationRequest(BaseModel):
 
     @validator("project_dir", always=True)
     def check_project_dir(cls, project_dir, values):
-        _resolve_project_dir(values["command"], project_dir)
+        resolve_project_dir(values["command"], project_dir)
         # We don't change incoming request, only validate it.
         return project_dir
 
@@ -446,7 +407,7 @@ class PostInvocationResponse(BaseModel):
 async def post_invocation(args: PostInvocationRequest):
     """Accepts user dbt invocation request, creates a task in task queue."""
     command = deepcopy(args.command)
-    _append_project_dir(command, args.project_dir)
+    append_project_dir(command, args.project_dir)
     task_id = str(uuid4()) if args.task_id is None else args.task_id
     # Manually store PENDING status in backend otherwise we can't tell apart
     # if task_id is missed or haven't been picked up by worker.

--- a/dbt_server/views.py
+++ b/dbt_server/views.py
@@ -448,13 +448,14 @@ async def post_invocation(args: PostInvocationRequest):
     command = deepcopy(args.command)
     _append_project_dir(command, args.project_dir)
     task_id = str(uuid4()) if args.task_id is None else args.task_id
-
     # Manually store PENDING status in backend otherwise we can't tell apart
     # if task_id is missed or haven't been picked up by worker.
     invoke.backend.store_result(task_id, None, PENDING)
     try:
         logger.info(f"Invoke: {command}, task_id: {task_id}")
-        invoke.apply_async(args=[command, args.callback_url], task_id=task_id)
+        invoke.apply_async(
+            args=[command, args.project_dir, args.callback_url], task_id=task_id
+        )
     except Exception as e:
         # If invocation is failed, change state to FAILURE. In strange case
         # that below store_result is failed, the request will always be PENDING.

--- a/dbt_server/views_test.py
+++ b/dbt_server/views_test.py
@@ -63,7 +63,7 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             )
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_URL], task_id=TEST_TASK_ID
+            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL], task_id=TEST_TASK_ID
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             TEST_TASK_ID, None, "PENDING"
@@ -88,7 +88,7 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             )
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_URL], task_id=TEST_TASK_ID
+            args=[TEST_COMMAND_WITH_PROJECT_DIR, None, TEST_URL], task_id=TEST_TASK_ID
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             TEST_TASK_ID, None, "PENDING"
@@ -111,7 +111,7 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             PostInvocationRequest(command=TEST_COMMAND, callback_url=TEST_URL)
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_URL], task_id=TEST_TASK_ID
+            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL], task_id=TEST_TASK_ID
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             TEST_TASK_ID, None, "PENDING"
@@ -134,7 +134,7 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             )
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND, TEST_URL], task_id="USER_TASK_ID"
+            args=[TEST_COMMAND, None, TEST_URL], task_id="USER_TASK_ID"
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             "USER_TASK_ID", None, "PENDING"

--- a/dbt_server/views_test.py
+++ b/dbt_server/views_test.py
@@ -63,7 +63,8 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             )
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL], task_id=TEST_TASK_ID
+            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL],
+            task_id=TEST_TASK_ID,
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             TEST_TASK_ID, None, "PENDING"
@@ -111,7 +112,8 @@ class TestPostInvocation(IsolatedAsyncioTestCase):
             PostInvocationRequest(command=TEST_COMMAND, callback_url=TEST_URL)
         )
         mock_invoke.apply_async.assert_called_once_with(
-            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL], task_id=TEST_TASK_ID
+            args=[TEST_COMMAND_WITH_PROJECT_DIR, TEST_DIR, TEST_URL],
+            task_id=TEST_TASK_ID,
         )
         mock_invoke.backend.store_result.assert_called_once_with(
             TEST_TASK_ID, None, "PENDING"

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -100,7 +100,6 @@ def _invoke_runner(
     # after a deps is called. Once core completes the following ticket, we can remove
     # this chdir hack: https://github.com/dbt-labs/dbt-core/issues/6985
     original_wd = os.getcwd()
-    project_dir = resolve_project_dir(command, project_dir)
     try:
         os.chdir(get_root_path(None, project_dir))
         dbt = dbtRunner()

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -1,6 +1,11 @@
+import os
+from dbt_server.flags import DBT_PROJECT_DIRECTORY
 from dbt_worker.app import app
 from dbt_server.logging import DBT_SERVER_LOGGER as logger
-from dbt_server.services.filesystem_service import get_task_artifacts_path
+from dbt_server.services.filesystem_service import (
+    get_task_artifacts_path,
+    get_root_path,
+)
 from celery.contrib.abortable import AbortableTask
 from celery.contrib.abortable import ABORTED
 from celery.exceptions import Ignore
@@ -19,6 +24,9 @@ from urllib3 import Retry
 # thread. It's used to poll abort status.
 JOIN_INTERVAL_SECONDS = 0.5
 LOG_PATH_ARGS = "--log-path"
+LOG_FORMAT_ARGS = "--log-format"
+LOG_FORMAT_DEFAULT = "json"
+PROJECT_DIR_ARGS = "--project-dir"
 
 
 def is_command_has_log_path(command: List[str]):
@@ -67,7 +75,11 @@ def _update_state(
 
 
 def _invoke_runner(
-    task: Any, task_id: str, command: List[str], callback_url: Optional[str]
+    task: Any,
+    task_id: str,
+    command: List[str],
+    project_dir: Optional[str],
+    callback_url: Optional[str],
 ):
     """Invokes dbt runner with `command`, update task state if any exception is
     raised.
@@ -78,7 +90,19 @@ def _invoke_runner(
         command: Dbt invocation command list.
         callback_url: If set, if core raises any error, a callback will be
             triggered."""
+
+    # Currently dbt-core does two things that necessitate this chdir logic:
+    # 1. If a command is run before deps, a dbt_packages folder is created wherever
+    #  the command is being run from
+    # 2. On deps, core calls chdir into the project directory and does not reset
+    # As a result, we see a dbt_packages dir created at the server root and/or
+    # task artifacts being written relative to the project instead of the server
+    # after a deps is called. Once core completes the following ticket, we can remove
+    # this chdir hack: https://github.com/dbt-labs/dbt-core/issues/6985
+    original_wd = os.getcwd()
+    project_dir = resolve_project_dir(command, project_dir)
     try:
+        os.chdir(get_root_path(None, project_dir))
         dbt = dbtRunner()
         _, _ = dbt.invoke(command)
     except Exception as e:
@@ -89,6 +113,8 @@ def _invoke_runner(
             {"exc_type": type(e).__name__, "exc_message": str(e)},
             callback_url,
         )
+    finally:
+        os.chdir(original_wd)
 
 
 def _get_task_status(task: Any, task_id: str):
@@ -103,9 +129,53 @@ def _insert_log_path(command: List[str], task_id: str):
         return
     command.insert(0, LOG_PATH_ARGS)
     command.insert(1, get_task_artifacts_path(task_id, None))
+    command.insert(2, LOG_FORMAT_ARGS)
+    command.insert(3, LOG_FORMAT_DEFAULT)
 
 
-def _invoke(task: Any, command: List[str], callback_url: Optional[str] = None):
+def _is_command_has_project_dir(command: List[str]) -> bool:
+    """Returns true if command has --project-dir args."""
+    # This approach is not 100% accurate but should be good for most cases.
+    return any([PROJECT_DIR_ARGS in item for item in command])
+
+
+def resolve_project_dir(
+    command: List[str], project_dir: Optional[str]
+) -> Optional[str]:
+    """Resolves request `project_path` and append --project-dir to `command` if
+    needed. Returns resolved project directory or None if can't resolve. Raises
+    AssertionError if --project-dir is found in command and project_dir is
+    provided."""
+
+    is_command_has_project_dir = _is_command_has_project_dir(command)
+    if project_dir and is_command_has_project_dir:
+        raise AssertionError(
+            "Confliction: --project-dir is found in command while project_dir field is also set."
+        )
+    if is_command_has_project_dir or project_dir:
+        return project_dir
+    # Fallback to environment variable.
+    default_project_dir = DBT_PROJECT_DIRECTORY.get()
+    return default_project_dir
+
+
+def append_project_dir(command: List[str], project_dir: Optional[str]) -> None:
+    """Resolves project directory and appends to command if needed. See
+    PostInvocationRequest.project_dir for more details.
+    """
+    if _is_command_has_project_dir(command):
+        return
+    resolved_project_dir = resolve_project_dir(command, project_dir)
+    if resolved_project_dir is not None:
+        command.extend([PROJECT_DIR_ARGS, resolved_project_dir])
+
+
+def _invoke(
+    task: Any,
+    command: List[str],
+    project_dir: Optional[str] = None,
+    callback_url: Optional[str] = None,
+):
     """Invokes dbt command.
     Args:
         command: Dbt commands that will be executed, e.g. ["run",
@@ -122,7 +192,9 @@ def _invoke(task: Any, command: List[str], callback_url: Optional[str] = None):
 
     # To support abort, we need to run dbt in a child thread, make parent thread
     # monitor abort signal and join with child thread.
-    t = Thread(target=_invoke_runner, args=[task, task_id, command, callback_url])
+    t = Thread(
+        target=_invoke_runner, args=[task, task_id, command, project_dir, callback_url]
+    )
     t.start()
     while t.is_alive():
         # TODO: Handle abort signal.
@@ -145,5 +217,10 @@ def _invoke(task: Any, command: List[str], callback_url: Optional[str] = None):
 
 
 @app.task(bind=True, track_started=True, base=AbortableTask)
-def invoke(self, command: List[str], callback_url: Optional[str] = None):
-    _invoke(self, command, callback_url)
+def invoke(
+    self,
+    command: List[str],
+    project_dir: Optional[str] = None,
+    callback_url: Optional[str] = None,
+):
+    _invoke(self, command, project_dir, callback_url)

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -88,6 +88,7 @@ def _invoke_runner(
         task: Celery task.
         task_id: Task id, it's required to update task state.
         command: Dbt invocation command list.
+        project_dir: directory to dbt project.
         callback_url: If set, if core raises any error, a callback will be
             triggered."""
 
@@ -179,6 +180,7 @@ def _invoke(
     Args:
         command: Dbt commands that will be executed, e.g. ["run",
             "--project-dir", "/a/b/jaffle_shop"].
+        project_dir: directory to dbt project
         callback_url: String, if set any time the task status is updated, worker
             will make a callback. Notice it's not complete, in some cases task
             status may be updated but we are not able to trigger callback, e.g.

--- a/dbt_worker/tasks_test.py
+++ b/dbt_worker/tasks_test.py
@@ -8,7 +8,15 @@ from unittest.mock import MagicMock
 TEST_LOG_PATH = "/test_path"
 TEST_COMMAND = ["run", "--flag", "test"]
 TEST_COMMAND_WITH_LOG_PATH = ["--log-path", "test", "run", "--flag", "test"]
-TEST_RESOLVED_COMMAND = ["--log-path", TEST_LOG_PATH, "run", "--flag", "test"]
+TEST_RESOLVED_COMMAND = [
+    "--log-path",
+    TEST_LOG_PATH,
+    "--log-format",
+    "json",
+    "run",
+    "--flag",
+    "test",
+]
 TEST_TASK_ID = "test_id"
 TEST_ERROR_MESSAGE = "test error"
 TEST_CALLBACK_URL = "test_url"
@@ -44,6 +52,7 @@ class TestInvoke(TestCase):
     def setUp(self) -> None:
         self.mock_task = MockTask()
         self.mock_dbt_runner = MagicMock()
+        self.project_path = "."
 
     def tearDown(self) -> None:
         mock_invoke_success.last_command = None
@@ -58,7 +67,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None, None)
+            _invoke(self.mock_task, TEST_COMMAND, self.project_path, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -76,7 +85,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND_WITH_LOG_PATH, None, None)
+            _invoke(self.mock_task, TEST_COMMAND_WITH_LOG_PATH, self.project_path, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_COMMAND_WITH_LOG_PATH)
         patched_dbt_runner.assert_called_once_with()
@@ -94,7 +103,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None, None)
+            _invoke(self.mock_task, TEST_COMMAND, self.project_path, None)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -117,7 +126,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None, TEST_CALLBACK_URL)
+            _invoke(self.mock_task, TEST_COMMAND, self.project_path, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -145,7 +154,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None, TEST_CALLBACK_URL)
+            _invoke(self.mock_task, TEST_COMMAND, self.project_path, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()

--- a/dbt_worker/tasks_test.py
+++ b/dbt_worker/tasks_test.py
@@ -58,7 +58,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None)
+            _invoke(self.mock_task, TEST_COMMAND, None, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -76,7 +76,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND_WITH_LOG_PATH, None)
+            _invoke(self.mock_task, TEST_COMMAND_WITH_LOG_PATH, None, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_COMMAND_WITH_LOG_PATH)
         patched_dbt_runner.assert_called_once_with()
@@ -94,7 +94,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, None)
+            _invoke(self.mock_task, TEST_COMMAND, None, None)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -117,7 +117,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, TEST_CALLBACK_URL)
+            _invoke(self.mock_task, TEST_COMMAND, None, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()
@@ -145,7 +145,7 @@ class TestInvoke(TestCase):
         self.mock_task.AsyncResult.return_value = started_state
 
         with self.assertRaises(Ignore) as _:
-            _invoke(self.mock_task, TEST_COMMAND, TEST_CALLBACK_URL)
+            _invoke(self.mock_task, TEST_COMMAND, None, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
         patched_dbt_runner.assert_called_once_with()


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Until core has completed [this bug ticket](https://github.com/dbt-labs/dbt-core/issues/6985), we need to intentionally chdir to the project root before running a dbt command, then chdir back to the server root afterward. This compensates for core 1. Writing an empty `dbt_packages` folder to wherever the command is being called (in our case, the server root, which we do not want)
2. Changing directories to the project root for a deps and not changing back, which prevents the server from specifying a task artifacts/project state folder that is relative to the server code path.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
