### PR TITLE
Give celery access to env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,3 @@ RUN pip install --force-reinstall MarkupSafe==2.0.1 # TODO: find better fix for 
 
 COPY ./dbt_server /usr/src/app/dbt_server
 COPY ./dbt_worker /usr/src/app/dbt_worker
-
-# TODO: Currently Celery worker user is "celery" instead of "root", dbt server 
-# has piece of code to create working-dir directory. Bad thing is Celery worker 
-# will try to create working-dir as well without write privilege and crashed 
-# eventually. This is bad behavior, in short we change root directory mod to 
-# 777, Celery worker can create working-dir as well. In long term we shouldn't 
-# let Celery worker do this directory initialization job.
-RUN chmod 777 /usr/src/app

--- a/bash/celeryd.sh
+++ b/bash/celeryd.sh
@@ -31,7 +31,11 @@
 # You can then configure this by manipulating /etc/default/little-worker.
 #
 VERSION=10.1
+
 echo "celery init v${VERSION}."
+# Source env vars exported in ubuntu-run.sh
+. /root/.bashrc
+echo $DBT_TARGET_PATH
 if [ $(id -u) -ne 0 ]; then
     echo "Error: This program can only be used by the root user."
     echo "       Unprivileged users must use the 'celery multi' utility, "

--- a/bash/celeryd.sh
+++ b/bash/celeryd.sh
@@ -35,7 +35,7 @@ VERSION=10.1
 echo "celery init v${VERSION}."
 # Source env vars exported in ubuntu-run.sh
 . /root/.bashrc
-echo $DBT_TARGET_PATH
+
 if [ $(id -u) -ne 0 ]; then
     echo "Error: This program can only be used by the root user."
     echo "       Unprivileged users must use the 'celery multi' utility, "

--- a/bash/ubuntu-run.sh
+++ b/bash/ubuntu-run.sh
@@ -13,6 +13,12 @@ if [ "${dbt_server_enable_ddtrace}" = "true" ]; then
     dd_trace="ddtrace-run gunicorn"
 fi
 
+# Export env vars to be sourced in celeryd script
+env_vars=$(printenv)
+while IFS= read -r line; do
+    echo "export $line" >> ~/.bashrc
+done <<< "$env_vars"
+
 service redis-server start
 service celeryd start
 

--- a/configs/celeryd
+++ b/configs/celeryd
@@ -20,9 +20,11 @@ CELERYD_LOG_LEVEL="INFO"
 CELERYD_LOG_FILE="/var/log/celery/%n%I.log"
 CELERYD_PID_FILE="/var/run/celery/%n.pid"
 
-# Workers should run as an unprivileged user.
-#   You need to create this user manually (or you can choose
-#   a user/group combination that already exists (e.g., nobody).
+# Run celery as the same user & group that invoked celery--
+# dbt-server writes files to locations specified by env var,
+# and in the IDE develop pods a specific unpriveledged user
+# is the only user given access to current locations, like the
+# dbt project filesystem
 CELERYD_USER=`id -un`
 CELERYD_GROUP=`id -gn`
 

--- a/configs/celeryd
+++ b/configs/celeryd
@@ -23,8 +23,9 @@ CELERYD_PID_FILE="/var/run/celery/%n.pid"
 # Workers should run as an unprivileged user.
 #   You need to create this user manually (or you can choose
 #   a user/group combination that already exists (e.g., nobody).
-CELERYD_USER="root"
-CELERYD_GROUP="root"
+CELERYD_USER=`id -un`
+CELERYD_GROUP=`id -gn`
+
 
 # If enabled pid and log directories will be created if missing,
 # and owned by the userid/group configured.

--- a/configs/celeryd
+++ b/configs/celeryd
@@ -23,8 +23,8 @@ CELERYD_PID_FILE="/var/run/celery/%n.pid"
 # Workers should run as an unprivileged user.
 #   You need to create this user manually (or you can choose
 #   a user/group combination that already exists (e.g., nobody).
-CELERYD_USER="celery"
-CELERYD_GROUP="celery"
+CELERYD_USER="root"
+CELERYD_GROUP="root"
 
 # If enabled pid and log directories will be created if missing,
 # and owned by the userid/group configured.

--- a/dbt_server/flags.py
+++ b/dbt_server/flags.py
@@ -86,6 +86,8 @@ DBT_WORKING_DIR = InMemoryFlag("__DBT_WORKING_DIR", "./working-dir")
 ALLOW_ORCHESTRATED_SHUTDOWN = InMemoryFlag("ALLOW_ORCHESTRATED_SHUTDOWN", "0")
 # Default dbt project directory. It's used to determine source code location.
 DBT_PROJECT_DIRECTORY = InMemoryFlag("DBT_PROJECT_DIRECTORY", None)
+# Default dbt invocation environment-- temporary to differentiate IDE usage
+DBT_CLOUD_CONTEXT = InMemoryFlag("DBT_CLOUD_CONTEXT", None)
 
 # Task queue configs.
 

--- a/dbt_server/logging.py
+++ b/dbt_server/logging.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional
 
 from dbt.events.eventmgr import EventLevel
-from dbt.events.base_types import BaseEvent
+from dbt.events.base_types import EventMsg
 from pythonjsonlogger import jsonlogger
 
 from dbt_server.models import TaskState
@@ -91,11 +91,11 @@ def configure_uvicorn_access_log():
 
 
 # Push event messages to root python logger for formatting
-def log_event_to_console(event: BaseEvent):
-    logging_method = dbt_event_to_python_root_log[event.log_level()]
-    if logging_method == logging.root.debug:
-        # Only log debug level for dbt-server logs
-        return
+def log_event_to_console(event: EventMsg):
+    logging_method = dbt_event_to_python_root_log[event.info.level]
+    # if logging_method == logging.root.debug:
+    #     # Only log debug level for dbt-server logs
+    #     return
     logging_method(event.info.msg)
 
 

--- a/dbt_server/logging.py
+++ b/dbt_server/logging.py
@@ -99,11 +99,6 @@ def log_event_to_console(event: BaseEvent):
     logging_method(event.info.msg)
 
 
-# TODO: Core is still working on a way to add a callback to the eventlogger using the
-# newer format. We will still need to do this for events emitted by core
-# EVENT_MANAGER.callbacks.append(log_event_to_console)
-
-
 # TODO: This should be some type of event. We may also choose to send events for all task state updates.
 @dataclass
 class ServerLog:

--- a/dbt_server/server.py
+++ b/dbt_server/server.py
@@ -6,6 +6,7 @@ from dbt_server import tracer  # noqa
 
 from dbt_server import models
 from dbt_server.database import engine
+from dbt_server.flags import DBT_CLOUD_CONTEXT
 from dbt_server.services import dbt_service, filesystem_service
 from dbt_server.views import app
 from dbt_server.logging import DBT_SERVER_LOGGER as logger, configure_uvicorn_access_log
@@ -83,4 +84,5 @@ async def startup_event():
     # This method is `async` intentionally to block serving until startup is complete
     configure_uvicorn_access_log()
     dbt_service.inject_dd_trace_into_core_lib()
-    startup_cache_initialize()
+    if DBT_CLOUD_CONTEXT.get() != "develop":
+        startup_cache_initialize()

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -103,7 +103,7 @@ def _invoke_runner(
     original_wd = os.getcwd()
     try:
         # If the project_dir was passed as a command flag, this
-        # value will be none. Command will still run properly, 
+        # value will be none. Command will still run properly,
         # artifacts may write to incorrect locations
         if project_dir:
             os.chdir(project_dir)

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -101,11 +101,12 @@ def _invoke_runner(
     # after a deps is called. Once core completes the following ticket, we can remove
     # this chdir hack: https://github.com/dbt-labs/dbt-core/issues/6985
     original_wd = os.getcwd()
-    root_path = get_root_path(None, project_dir)
     try:
-        # TODO: enforce provision of project path upstream to avoid null path here
-        if root_path:
-            os.chdir(root_path)
+        # If the project_dir was passed as a command flag, this
+        # value will be none. Command will still run properly, 
+        # artifacts may write to incorrect locations
+        if project_dir:
+            os.chdir(project_dir)
         # TODO: Make sure callback works
         dbt = dbtRunner(callbacks=[log_event_to_console])
         _, _ = dbt.invoke(command)

--- a/dbt_worker/tasks_test.py
+++ b/dbt_worker/tasks_test.py
@@ -58,8 +58,9 @@ class TestInvoke(TestCase):
         mock_invoke_success.last_command = None
         mock_invoke_failure.last_command = None
 
+    @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_success(self, patched_dbt_runner, _):
+    def test_success(self, patched_dbt_runner, patched_callback, _):
         patched_dbt_runner.return_value = self.mock_dbt_runner
         self.mock_dbt_runner.invoke = mock_invoke_success
         started_state = EmptyClass()
@@ -70,14 +71,15 @@ class TestInvoke(TestCase):
             _invoke(self.mock_task, TEST_COMMAND, self.project_path, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
-        patched_dbt_runner.assert_called_once_with()
+        patched_dbt_runner.assert_called_once_with(callbacks=[patched_callback])
         self.mock_task.AsyncResult.assert_called_once_with(TEST_TASK_ID)
         self.mock_task.update_state.assert_called_once_with(
             task_id=TEST_TASK_ID, state="SUCCESS", meta={}
         )
 
+    @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_ignore_log_path(self, patched_dbt_runner, _):
+    def test_ignore_log_path(self, patched_dbt_runner, patched_callback, _):
         patched_dbt_runner.return_value = self.mock_dbt_runner
         self.mock_dbt_runner.invoke = mock_invoke_success
         started_state = EmptyClass()
@@ -88,14 +90,15 @@ class TestInvoke(TestCase):
             _invoke(self.mock_task, TEST_COMMAND_WITH_LOG_PATH, self.project_path, None)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_COMMAND_WITH_LOG_PATH)
-        patched_dbt_runner.assert_called_once_with()
+        patched_dbt_runner.assert_called_once_with(callbacks=[patched_callback])
         self.mock_task.AsyncResult.assert_called_once_with(TEST_TASK_ID)
         self.mock_task.update_state.assert_called_once_with(
             task_id=TEST_TASK_ID, state="SUCCESS", meta={}
         )
 
+    @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_failure(self, patched_dbt_runner, _):
+    def test_failure(self, patched_dbt_runner, patched_callback, _):
         patched_dbt_runner.return_value = self.mock_dbt_runner
         self.mock_dbt_runner.invoke = mock_invoke_failure
         started_state = EmptyClass()
@@ -106,7 +109,7 @@ class TestInvoke(TestCase):
             _invoke(self.mock_task, TEST_COMMAND, self.project_path, None)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
-        patched_dbt_runner.assert_called_once_with()
+        patched_dbt_runner.assert_called_once_with(callbacks=[patched_callback])
         self.mock_task.update_state.assert_called_once_with(
             task_id=TEST_TASK_ID,
             state="FAILURE",
@@ -115,8 +118,9 @@ class TestInvoke(TestCase):
 
     @patch("dbt_worker.tasks.Retry", return_value=None)
     @patch("dbt_worker.tasks.Session", return_value=MagicMock())
+    @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_success_callback(self, patched_dbt_runner, patched_session, _, __):
+    def test_success_callback(self, patched_dbt_runner, patched_callback, patched_session, _, __):
         patched_session.return_value.mount.return_value = None
         patched_session.return_value.post.return_value = None
         patched_dbt_runner.return_value = self.mock_dbt_runner
@@ -129,7 +133,7 @@ class TestInvoke(TestCase):
             _invoke(self.mock_task, TEST_COMMAND, self.project_path, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_success.last_command, TEST_RESOLVED_COMMAND)
-        patched_dbt_runner.assert_called_once_with()
+        patched_dbt_runner.assert_called_once_with(callbacks=[patched_callback])
         patched_session.return_value.post.assert_any_call(
             TEST_CALLBACK_URL, json={"task_id": TEST_TASK_ID, "status": "STARTED"}
         )
@@ -143,8 +147,9 @@ class TestInvoke(TestCase):
 
     @patch("dbt_worker.tasks.Retry", return_value=None)
     @patch("dbt_worker.tasks.Session", return_value=MagicMock())
+    @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_failure_callback(self, patched_dbt_runner, patched_session, _, __):
+    def test_failure_callback(self, patched_dbt_runner, patched_callback, patched_session, _, __):
         patched_session.return_value.mount.return_value = None
         patched_session.return_value.post.return_value = None
         patched_dbt_runner.return_value = self.mock_dbt_runner
@@ -157,7 +162,7 @@ class TestInvoke(TestCase):
             _invoke(self.mock_task, TEST_COMMAND, self.project_path, TEST_CALLBACK_URL)
 
         self.assertEqual(mock_invoke_failure.last_command, TEST_RESOLVED_COMMAND)
-        patched_dbt_runner.assert_called_once_with()
+        patched_dbt_runner.assert_called_once_with(callbacks=[patched_callback])
         patched_session.return_value.post.assert_any_call(
             TEST_CALLBACK_URL, json={"task_id": TEST_TASK_ID, "status": "STARTED"}
         )

--- a/dbt_worker/tasks_test.py
+++ b/dbt_worker/tasks_test.py
@@ -120,7 +120,9 @@ class TestInvoke(TestCase):
     @patch("dbt_worker.tasks.Session", return_value=MagicMock())
     @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_success_callback(self, patched_dbt_runner, patched_callback, patched_session, _, __):
+    def test_success_callback(
+        self, patched_dbt_runner, patched_callback, patched_session, _, __
+    ):
         patched_session.return_value.mount.return_value = None
         patched_session.return_value.post.return_value = None
         patched_dbt_runner.return_value = self.mock_dbt_runner
@@ -149,7 +151,9 @@ class TestInvoke(TestCase):
     @patch("dbt_worker.tasks.Session", return_value=MagicMock())
     @patch("dbt_worker.tasks.log_event_to_console")
     @patch("dbt_worker.tasks.dbtRunner")
-    def test_failure_callback(self, patched_dbt_runner, patched_callback, patched_session, _, __):
+    def test_failure_callback(
+        self, patched_dbt_runner, patched_callback, patched_session, _, __
+    ):
         patched_session.return_value.mount.return_value = None
         patched_session.return_value.post.return_value = None
         patched_dbt_runner.return_value = self.mock_dbt_runner


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This copies env vars from the kubernetes container and sources them where the celery worker can access them. Also includes a minor change to the callback for core logs-- this callback is not currently helping us, but the Event type structure changed so I'm keeping at least that work for now, with a note to make it work.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
