### PR TITLE
Fixes invoke return type to allow class and tuple

### DIFF
--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -109,7 +109,7 @@ def _invoke_runner(
             os.chdir(project_dir)
         # TODO: Make sure callback works
         dbt = dbtRunner(callbacks=[log_event_to_console])
-        _, _ = dbt.invoke(command)
+        _ = dbt.invoke(command)
     except Exception as e:
         _update_state(
             task,

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -109,7 +109,7 @@ def _invoke_runner(
             os.chdir(project_dir)
         # TODO: Make sure callback works
         dbt = dbtRunner(callbacks=[log_event_to_console])
-        _ = dbt.invoke(command)
+        dbt.invoke(command)
     except Exception as e:
         _update_state(
             task,


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
In the latest core commit, the tuple that was returned from `dbtRunner.invoke()` was changed to a DbtRunnerResult object. We don't do anything with this value anyway, keeping a single underscore as it will cover both cases

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
