### PR TITLE
Implements handled dbt error case

### DIFF
--- a/dbt_server/services/dbt_service.py
+++ b/dbt_server/services/dbt_service.py
@@ -95,13 +95,9 @@ def parse_to_manifest(project_path, args):
             write_manifest=False,
         )
         if result and type(result) == dbtRunnerResult and not result.success:
-            # TODO: Dig into instances where exception is not returned from core
+            # If task had unhandled errors, raise
             if result.exception:
                 raise result.exception
-            else:
-                logger.error(
-                    "Task was unsuccessful but no exception was returned from dbt-core"
-                )
         return result.result
     except CompilationException as e:
         logger.error(
@@ -149,13 +145,9 @@ def compile_sql(manifest, project_dir, sql_config):
             and type(run_result) == dbtRunnerResult
             and not run_result.success
         ):
-            # TODO: Dig into instances where exception is not returned from core
+            # If task had unhandled errors, raise
             if run_result.exception:
                 raise run_result.exception
-            else:
-                logger.error(
-                    "Task was unsuccessful but no exception was returned from dbt-core"
-                )
         # convert to RemoteCompileResult to keep original return format
         node_result = run_result.result.results[0]
         result = RemoteCompileResult(

--- a/dbt_worker/tasks.py
+++ b/dbt_worker/tasks.py
@@ -121,12 +121,16 @@ def _invoke_runner(
         # dbt-core 1.5.0-latest changes the return type from a tuple to a
         #  dbtRunnerResult obj and no longer raises exceptions on invoke
         if result and type(result) == dbtRunnerResult and not result.success:
-            # TODO: Dig into instances where exception is not returned from core
+            # If task had unhandled errors, raise them
             if result.exception:
                 raise result.exception
             else:
-                logger.error(
-                    "Task was unsuccessful but no exception was returned from dbt-core"
+                _update_state(
+                    task,
+                    task_id,
+                    FAILURE,
+                    None,
+                    callback_url,
                 )
         logger.info(f"Task with id: {task_id} has completed")
     except Exception as e:


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Currently dbt-core will return dbtRunnerResult(success=False, exception=None, ...) when a task failed gracefully, but dbt-server always expects an exception or sets state to SUCCESS. 

This PR updates task state in redis to `FAILURE` even if there is no exception data from core, and removes unnecessary loglines for acceptable core error state.

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
