### PR TITLE
update used gh actions ahead of set-output, node12 deprecation

### DIFF
--- a/.changes/unreleased/Under the Hood-20230515-142830.yaml
+++ b/.changes/unreleased/Under the Hood-20230515-142830.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: update Github Action versions
+time: 2023-05-15T14:28:30.718775-05:00
+custom:
+  Author: davidbloss
+  Issue: "222"
+  PR: "226"

--- a/.github/_README.md
+++ b/.github/_README.md
@@ -63,12 +63,12 @@ permissions:
   contents: read
   pull-requests: write
 ```
-    
+
 ### Secrets
 - When to use a [Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) vs the [GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) generated for the action?
 
     The `GITHUB_TOKEN` is used by default.  In most cases it is sufficient for what you need.
-    
+
     If you expect the workflow to result in a commit to that should retrigger workflows, you will need to use a Personal Access Token for the bot to commit the file. When using the GITHUB_TOKEN, the resulting commit will not trigger another GitHub Actions Workflow run. This is due to limitations set by GitHub. See [the docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) for a more detailed explanation.
 
     For example, we must use a PAT in our workflow to commit a new changelog yaml file for bot PRs.  Once the file has been committed to the branch, it should retrigger the check to validate that a changelog exists on the PR.  Otherwise, it would stay in a failed state since the check would never retrigger.
@@ -105,7 +105,7 @@ Some triggers of note that we use:
 
   ```
   # **what?**
-  # Describe what the action does.  
+  # Describe what the action does.
 
   # **why?**
   # Why does this action exist?
@@ -158,7 +158,7 @@ Some triggers of note that we use:
         echo "The build_script_path:              ${{ inputs.build_script_path }}"
         echo "The s3_bucket_name:                 ${{ inputs.s3_bucket_name }}"
         echo "The package_test_command:           ${{ inputs.package_test_command }}"
-      
+
     # collect all the variables that need to be used in subsequent jobs
     - name: Set Variables
       id: variables
@@ -190,14 +190,14 @@ ___
 ### Actions from the Marketplace
 - Don’t use external actions for things that can easily be accomplished manually.
 - Always read through what an external action does before using it!  Often an action in the GitHub Actions Marketplace can be replaced with a few lines in bash.  This is much more maintainable (and won’t change under us) and clear as to what’s actually happening.  It also prevents any
-- Pin actions _we don't control_ to tags. 
+- Pin actions _we don't control_ to tags.
 
 ### Connecting to AWS
 - Authenticate with the aws managed workflow
 
   ```yaml
   - name: Configure AWS credentials from Test account
-    uses: aws-actions/configure-aws-credentials@v1
+    uses: aws-actions/configure-aws-credentials@v1-node16
     with:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -208,7 +208,7 @@ ___
 
   ```yaml
   - name: Copy Artifacts from S3 via CLI
-    run: aws s3 cp ${{ env.s3_bucket }} . --recursive 
+    run: aws s3 cp ${{ env.s3_bucket }} . --recursive
   ```
 
 ### Testing

--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -37,7 +37,7 @@ runs:
   steps:
     - name: setup docker buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: build and publish docker image
       uses: docker/build-push-action@v2

--- a/.github/actions/registry-login-action/action.yml
+++ b/.github/actions/registry-login-action/action.yml
@@ -32,20 +32,20 @@ runs:
   using: "composite"
   steps:
     - name: login to the development container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.development-registry-endpoint }}
         username: ${{ inputs.development-registry-username }}
         password: ${{ inputs.development-registry-password }}
     - name: login to the staging container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.staging-registry-endpoint }}
         username: ${{ inputs.staging-registry-username }}
         password: ${{ inputs.staging-registry-password }}
 
     - name: login to the production container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.production-registry-endpoint }}
         username: ${{ inputs.production-registry-username }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
             package: dbt-redshift
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: registry login
         uses: ./.github/actions/registry-login-action


### PR DESCRIPTION
## What is this PR?
Follow-up to https://github.com/dbt-labs/dbt-server/pull/220

resolves https://github.com/dbt-labs/dbt-server/issues/222

Update versions of used Github Actions ahead of:

[node12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Summer 2023)
[set-output deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) (fully disabled on 31st May 2023)

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them. Be as descriptive as possible!
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
