### PR TITLE
Add health checks for server processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get -y update && apt-get -y upgrade && \
   apt-get -y update --fix-missing && \
   apt-get -y install && apt-get -y upgrade && \
   apt-get -y install software-properties-common && \
+  apt-get -y install curl && \
+  apt-get -y install iputils-ping &&\
   apt-get -y install git libpq-dev openssh-client openssl && \
   apt-get -y autoremove && \
   rm -rf /var/lib/apt/lists/*

--- a/bash/liveliness.sh
+++ b/bash/liveliness.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# First, make a call to the ready server endpoint. It should return 200
+response=$(curl -s -o /dev/null -w "%{http_code}" localhost:8585/ready)
+
+# Check if the response status code is 200
+if [ "$response" -eq 200 ]; then
+  # Set default value for CELERY_BROKER_URL if not already set
+  CELERY_BROKER_URL=${CELERY_BROKER_URL:-redis://localhost:6379/0}
+
+  # Check if the broker is reachable
+  if redis-cli -u "$CELERY_BROKER_URL" PING > /dev/null 2>&1; then
+    # Check the time difference between the current timestamp and the last modification timestamp
+    # of the worker_heartbeat file. This will also eval to False if the file doesn't exist yet.
+    if test $(($(date +%s) - $(stat -c %Y /tmp/worker_heartbeat))) -lt 10; then
+      # Both checks passed, return 1
+      exit 1
+    fi
+  fi
+fi
+
+# Either of the checks failed, return 0
+exit 0

--- a/dbt_worker/app.py
+++ b/dbt_worker/app.py
@@ -1,4 +1,6 @@
-from celery import Celery
+from pathlib import Path
+from celery import Celery, bootsteps
+from celery.signals import worker_ready, worker_shutdown
 from dbt_server.flags import CELERY_BACKEND_URL
 from dbt_server.flags import CELERY_BROKER_URL
 from dbt_worker import celeryconfig
@@ -15,6 +17,44 @@ app = Celery(
 )
 
 app.config_from_object(celeryconfig)
+
+HEARTBEAT_FILE = Path("/tmp/worker_heartbeat")
+READINESS_FILE = Path("/tmp/worker_ready")
+
+
+class LivenessProbe(bootsteps.StartStopStep):
+    requires = {"celery.worker.components:Timer"}
+
+    def __init__(self, worker, **kwargs):
+        self.requests = []
+        self.tref = None
+
+    def start(self, worker):
+        self.tref = worker.timer.call_repeatedly(
+            1.0,
+            self.update_heartbeat_file,
+            (worker,),
+            priority=10,
+        )
+
+    def stop(self, worker):
+        HEARTBEAT_FILE.unlink(missing_ok=True)
+
+    def update_heartbeat_file(self, worker):
+        HEARTBEAT_FILE.touch()
+
+
+@worker_ready.connect
+def worker_ready(**_):
+    READINESS_FILE.touch()
+
+
+@worker_shutdown.connect
+def worker_shutdown(**_):
+    READINESS_FILE.unlink(missing_ok=True)
+
+
+app.steps["worker"].add(LivenessProbe)
 
 if __name__ == "__main__":
     app.start()


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Adds liveliness tracking using celery signals and a shell script that can be used to check readiness and liveliness. This PR is in conjunction with [dbt-cloud PR #7344](https://github.com/dbt-labs/dbt-cloud/pull/7344).

The bash script:
1. Sends an http request to the `/ready` endpoint of dbt-server to make sure server itself is up
2. Makes sure the broker can be accessed via the command `redis-cli` and sending a ping
3. Verifies that a file `/tmp/worker_heartbeat` exists and has been touched in the last 10 seconds (this `touch` command is executed once the worker is ready, then again as a part of the celery worker's steps, making use of celery signals)

These steps should confirm that the server is started and running, the redis broker can be connected to, and the celery workers are live. 

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
