### PR TITLE
Add support to run celery workers and Gunicorn as non-root

### DIFF
--- a/.changes/unreleased/Features-20230526-092501.yaml
+++ b/.changes/unreleased/Features-20230526-092501.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add ability to run Celery workers and Gunicorn as a non-root user
+time: 2023-05-26T09:25:01.830182-04:00
+custom:
+  Author: isaac-taylor
+  Issue: "2286"
+  PR: "123"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ RUN apt-get -y update && apt-get -y upgrade && \
 
 WORKDIR /usr/src/app
 
+RUN groupadd -g 999 restricted && \
+  useradd -s /bin/sh \
+  -m -d /home/restricted \
+  -r -u 999 -g restricted restricted
+
 COPY ./bash /usr/src/app/bash
 # Copy celery config and serviced.
 COPY ./configs/celeryd /etc/default/celeryd

--- a/configs/celeryd
+++ b/configs/celeryd
@@ -20,11 +20,7 @@ CELERYD_LOG_FILE="/var/log/celery/celery-all.log"
 # %n will be replaced with the first part of the nodename.
 CELERYD_PID_FILE="/var/run/celery/%n.pid"
 
-# Run celery as the same user & group that invoked celery--
-# dbt-server writes files to locations specified by env var,
-# and in the IDE develop pods a specific unpriveledged user
-# is the only user given access to current locations, like the
-# dbt project filesystem
+# IDE Develop Pods use this to run celeary workers as nonroot
 CELERYD_USER="${DBT_SERVER_USER-root}"
 CELERYD_GROUP="${DBT_SERVER_USER-root}"
 

--- a/configs/celeryd
+++ b/configs/celeryd
@@ -25,8 +25,8 @@ CELERYD_PID_FILE="/var/run/celery/%n.pid"
 # and in the IDE develop pods a specific unpriveledged user
 # is the only user given access to current locations, like the
 # dbt project filesystem
-CELERYD_USER=`id -un`
-CELERYD_GROUP=`id -gn`
+CELERYD_USER="${DBT_SERVER_USER-root}"
+CELERYD_GROUP="${DBT_SERVER_USER-root}"
 
 
 # If enabled pid and log directories will be created if missing,


### PR DESCRIPTION
## What is this PR?

Currently dbt-server is not able to run as non-root, which means is fails to start in production!

This PR (and another with dbt-server) =, enable dbt-server to start up as root, but ensure celery workers and the server itself are run as a non-root user.

This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Required to use dbt-server in Develop Pods in production

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
