### PR TITLE
Fixes bash command typo

### DIFF
--- a/bash/ubuntu-run.sh
+++ b/bash/ubuntu-run.sh
@@ -9,7 +9,6 @@ readonly dbt_server_port="${DBT_SERVER_WORKER_PORT-8585}"
 readonly dbt_server_max_requests="${DBT_SERVER_MAX_REQUESTS-5}"
 
 readonly dbt_server_user="${DBT_SERVER_USER-root}"
-echo $dbt_server_user
 
 gunicorn="gunicorn"
 if [ "${dbt_server_enable_ddtrace}" = "true" ]; then


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Gunicorn startup command was throwing an error, this quiets the error about command `dbt_server_user` not being found

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [x] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [ ] I have added an entry to CHANGELOG.md
