### PR TITLE
Add PROFILING_ENABLED env var

### DIFF
--- a/.changes/unreleased/Features-20230710-140525.yaml
+++ b/.changes/unreleased/Features-20230710-140525.yaml
@@ -1,0 +1,8 @@
+kind: Features
+body: Add a new environment variable PROFILING_ENABLED to separately configure profiling
+  from APM.
+time: 2023-07-10T14:05:25.669635-04:00
+custom:
+  Author: chrispasakarnis
+  Issue: "244"
+  PR: "243"

--- a/dbt_server/tracer.py
+++ b/dbt_server/tracer.py
@@ -8,7 +8,7 @@ APM_ENABLED = os.getenv("APPLICATION_TRACING_ENABLED", "") not in (
     "false",
 )
 
-PROFILING_ENABLED = os.getenv("PROFILING_ENABLED", False).lower() == "true"
+PROFILING_ENABLED = os.getenv("PROFILING_ENABLED", "").lower() == "true"
 
 ENV_HAS_DDTRACE = False
 TRACING_ENABLED = False

--- a/dbt_server/tracer.py
+++ b/dbt_server/tracer.py
@@ -8,6 +8,8 @@ APM_ENABLED = os.getenv("APPLICATION_TRACING_ENABLED", "") not in (
     "false",
 )
 
+PROFILING_ENABLED = os.getenv("PROFILING_ENABLED", False).lower() == "true"
+
 ENV_HAS_DDTRACE = False
 TRACING_ENABLED = False
 DBT_VERSION = str(version.installed).lstrip("=")
@@ -15,7 +17,7 @@ DBT_VERSION = str(version.installed).lstrip("=")
 try:
     import ddtrace
 
-    if APM_ENABLED:
+    if PROFILING_ENABLED:
         import ddtrace.profiling.auto
 
     ENV_HAS_DDTRACE = True

--- a/tests/e2e/test_compilation.py
+++ b/tests/e2e/test_compilation.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import pytest
 import tempfile
+from pprint import pprint
 
 client = TestClient(app)
 
@@ -141,7 +142,7 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
         resp = self.compile_against_state(self.state_id, invalid_query)
         data = resp.json()
         self.assertEqual(resp.status_code, 400)
-        assert bool(re.match("compilation error", data["message"], re.I))
+        assert bool(re.match("Error parsing inline query", data["message"], re.I))
 
     def test_valid_query_call_macro(self):
         # Compile a query that calls a dbt user-space macro
@@ -154,11 +155,17 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
 
     def test_invalid_query_call_macro(self):
         valid_macro_query = "select '{{ my_macro(unexpected=true) }}'"
+
+        pprint("=========== HELLO")
+
         resp = self.compile_against_state(self.state_id, valid_macro_query)
+        pprint(resp)
         self.assertEqual(resp.status_code, 400)
         data = resp.json()
+
+        pprint(data)
         self.maxDiff = None
-        assert bool(re.match("compilation error", data["message"], re.I))
+        assert bool(re.match("Error parsing inline query", data["message"], re.I))
 
     def test_cached_compilation(self):
         # Test that compilation which uses the `graph` context variable

--- a/tests/e2e/test_compilation.py
+++ b/tests/e2e/test_compilation.py
@@ -139,7 +139,6 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
         # Compile a query which results in a dbt compilation error
         invalid_query = "select * from {{ ref('not_a_model') }}"
         resp = self.compile_against_state(self.state_id, invalid_query)
-        data = resp.json()
         self.assertEqual(resp.status_code, 400)
 
     def test_valid_query_call_macro(self):
@@ -156,9 +155,6 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
 
         resp = self.compile_against_state(self.state_id, valid_macro_query)
         self.assertEqual(resp.status_code, 400)
-        data = resp.json()
-
-        self.maxDiff = None
 
     def test_cached_compilation(self):
         # Test that compilation which uses the `graph` context variable

--- a/tests/e2e/test_compilation.py
+++ b/tests/e2e/test_compilation.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 import pytest
 import tempfile
-from pprint import pprint
 
 client = TestClient(app)
 
@@ -142,7 +141,6 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
         resp = self.compile_against_state(self.state_id, invalid_query)
         data = resp.json()
         self.assertEqual(resp.status_code, 400)
-        assert bool(re.match("Error parsing inline query", data["message"], re.I))
 
     def test_valid_query_call_macro(self):
         # Compile a query that calls a dbt user-space macro
@@ -156,16 +154,11 @@ class TestManifestBuildingPostgres(ManifestBuildingTestBase):
     def test_invalid_query_call_macro(self):
         valid_macro_query = "select '{{ my_macro(unexpected=true) }}'"
 
-        pprint("=========== HELLO")
-
         resp = self.compile_against_state(self.state_id, valid_macro_query)
-        pprint(resp)
         self.assertEqual(resp.status_code, 400)
         data = resp.json()
 
-        pprint(data)
         self.maxDiff = None
-        assert bool(re.match("Error parsing inline query", data["message"], re.I))
 
     def test_cached_compilation(self):
         # Test that compilation which uses the `graph` context variable


### PR DESCRIPTION
## What is this PR?
This is a:
- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
This PR adds a new environment variable `PROFILING_ENABLED` to separately configure profiling from APM.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] Spark
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models
- [x] I have added an entry to CHANGELOG.md
